### PR TITLE
fix: use strict package manager version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -16,5 +16,5 @@ runs:
 
     - run: pnpm install --frozen-lockfile
       shell: bash
-    
+
     - uses: nrwl/nx-set-shas@v4

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        version: 10.2.1
+        version: 10.11.0
 
       # Cache node_modules
     - uses: actions/setup-node@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 link-workspace-packages=true
 auto-install-peers=true
+package-manager-strict=true
+package-manager-strict-version=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,20 +24,11 @@ cd /path/to/cloned/rnef/
 pnpm link-packages
 ```
 
-And then in your test project:
+And then in your test project link dependencies you're using, e.g.:
 
 ```sh
 cd /my/test/project/
-pnpm link --global "@rnef/cli" "@rnef/config" "@rnef/tools" "@rnef/platform-android" "@rnef/platform-ios" "@rnef/platform-apple-helpers" "@rnef/create-app" "@rnef/plugin-metro" "@rnef/plugin-repack" "@rnef/plugin-brownfield-ios"
-```
-
-Update entries in package.json to look like this:
-
-```json
-{
-  "@rnef/cli": "link:../../rnef/packages/cli",
-  "@rnef/platform-android": "link:../../rnef/packages/platform-android"
-}
+pnpm link @rnef/cli @rnef/platform-android @rnef/platform-ios @rnef/plugin-metro
 ```
 
 #### Hoist pnpm dependencies

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
   "nx": {
     "includedScripts": []
   },
-  "packageManager": "pnpm@10.2.1"
+  "packageManager": "pnpm@10.11.0"
 }

--- a/scripts/linkPackages.mjs
+++ b/scripts/linkPackages.mjs
@@ -9,5 +9,5 @@ const pm = pmArg.replace('--', '');
 for (const project of projects) {
   const cwd = path.dirname(project);
   console.log(`Running "${pm} link" in ${cwd}`);
-  await spawn(pm, ['link', '--global'], { cwd, stdio: 'inherit' });
+  await spawn(pm, ['link'], { cwd, stdio: 'inherit' });
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When deploying https://github.com/callstack/rnef/pull/208 we hit some weird issues related to pnpm version, in this PR I've added relevant configuration options which will ensure correct package manager and correct version will be used.

### Test plan

`pnpm install` works in the same way as before 👍