### PR TITLE
fix(apple): Improve device matching by name

### DIFF
--- a/packages/platform-apple-helpers/src/lib/commands/run/matchingDevice.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/matchingDevice.ts
@@ -3,14 +3,17 @@ import type { Device } from '../../types/index.js';
 export function matchingDevice(devices: Array<Device>, deviceArg: string) {
   const deviceByName = devices.find(
     (device) =>
-      device.name === deviceArg || formattedDeviceName(device) === deviceArg
+      device.name === deviceArg ||
+      formattedDeviceName(device, true) === deviceArg ||
+      formattedDeviceName(device, false) === deviceArg
   );
   const deviceByUdid = devices.find((d) => d.udid === deviceArg);
   return deviceByName || deviceByUdid;
 }
 
-export function formattedDeviceName(simulator: Device) {
+export function formattedDeviceName(simulator: Device, replaceIOS: boolean) {
+  const bareVersion = simulator.version?.replace(/^iOS /, '');
   return simulator.version
-    ? `${simulator.name} (${simulator.version})`
+    ? `${simulator.name} (${replaceIOS ? bareVersion : simulator.version})`
     : simulator.name;
 }


### PR DESCRIPTION
## Improve device matching by name

This PR enhances the device matching logic in `platform-apple-helpers` to allow finding devices by name even if the user specifies the version without the "iOS " prefix (e.g., "iPhone 15 (17.0)").

## Testing:

1.  Try running a command targeting that simulator using the full name (e.g., `--device "iPhone 15 (iOS 17.4)"`). Verify it works.
3.  Try running the same command, but omit the "iOS " prefix from the device name (e.g., `--device "iPhone 15 (17.4)"`). Verify it still correctly targets the intended simulator.