### PR TITLE
fix: always use udid from matched device

### DIFF
--- a/.changeset/blue-dingos-carry.md
+++ b/.changeset/blue-dingos-carry.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: always use udid from matched device

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -73,6 +73,7 @@ export const buildProject = async ({
   scheme,
   configuration,
   args,
+  deviceName,
 }: {
   xcodeProject: XcodeProjectInfo;
   sourceDir: string;
@@ -81,6 +82,7 @@ export const buildProject = async ({
   scheme: string;
   configuration: string;
   args: RunFlags | BuildFlags;
+  deviceName?: string;
 }) => {
   const simulatorDest = simulatorDestinationMap[platformName];
 
@@ -106,23 +108,16 @@ export const buildProject = async ({
       }
     }
 
-    if ('device' in args && args.device) {
-      // Check if the device argument looks like a UDID (assuming UDIDs are alphanumeric and have specific length)
-      const isUDID = /^[A-Fa-f0-9-]{25,}$/.test(args.device);
-      if (isUDID) {
-        return [`id=${args.device}`];
-      } else {
-        // If it's a device name
-        return [`name=${args.device}`];
-      }
-    }
-
     if ('catalyst' in args && args.catalyst) {
       return ['platform=macOS,variant=Mac Catalyst'];
     }
 
     if (udid) {
       return [`id=${udid}`];
+    }
+
+    if (deviceName) {
+      return [`name=${deviceName}`];
     }
 
     return [`generic/platform=${platformName}`];

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -91,6 +91,7 @@ export const createRun = async (
   }
   loader.stop('Found available devices and simulators.');
   const device = await selectDevice(devices, args);
+  args.device = device?.udid
 
   if (device) {
     cacheRecentDevice(device, platformName);

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -41,7 +41,7 @@ export const createRun = async (
   if (!args.binaryPath && args.remoteCache) {
     const cachedBuild = await fetchCachedBuild({
       configuration: args.configuration ?? 'Debug',
-      distribution: args.destination ?? (args.device ? 'device' : 'simulator'),
+      distribution: args.destination ?? 'simulator',
       remoteCacheProvider,
       root: projectRoot,
       fingerprintOptions,
@@ -54,6 +54,15 @@ export const createRun = async (
 
   validateArgs(args, projectRoot);
 
+  // Check if the device argument looks like a UDID
+  // (assuming UDIDs are alphanumeric and have specific length)
+  const udid =
+    args.device && /^[A-Fa-f0-9-]{25,}$/.test(args.device)
+      ? args.device
+      : undefined;
+
+  const deviceName = udid ? undefined : args.device;
+
   if (platformName === 'macos') {
     const { appPath } = await buildApp({
       args,
@@ -61,6 +70,8 @@ export const createRun = async (
       platformName,
       platformSDK: getSimulatorPlatformSDK(platformName),
       projectRoot,
+      udid,
+      deviceName,
     });
     await runOnMac(appPath);
     return;
@@ -71,6 +82,8 @@ export const createRun = async (
       platformName,
       platformSDK: getSimulatorPlatformSDK(platformName),
       projectRoot,
+      udid,
+      deviceName,
     });
     if (scheme) {
       await runOnMacCatalyst(appPath, scheme);
@@ -91,10 +104,6 @@ export const createRun = async (
   }
   loader.stop('Found available devices and simulators.');
   const device = await selectDevice(devices, args);
-
-  // we need to override the device arg because that's what is used to build the app
-  // and we need also to include udid because that's what works in all the cases
-  args.device = device?.udid;
 
   if (device) {
     cacheRecentDevice(device, platformName);
@@ -176,8 +185,6 @@ async function selectDevice(devices: Device[], args: RunFlags) {
     logger.warn(
       `No devices or simulators found matching "${args.device}". Falling back to default simulator.`
     );
-    // setting device to undefined to avoid buildProject to use it
-    args.device = undefined;
   }
   return device;
 }

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -91,7 +91,10 @@ export const createRun = async (
   }
   loader.stop('Found available devices and simulators.');
   const device = await selectDevice(devices, args);
-  args.device = device?.udid
+
+  // we need to override the device arg because that's what is used to build the app
+  // and we need also to include udid because that's what works in all the cases
+  args.device = device?.udid;
 
   if (device) {
     cacheRecentDevice(device, platformName);

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -21,6 +21,7 @@ export async function buildApp({
   platformSDK,
   udid,
   projectRoot,
+  deviceName,
 }: {
   args: RunFlags | BuildFlags;
   projectConfig: ProjectConfig;
@@ -28,6 +29,7 @@ export async function buildApp({
   platformName: ApplePlatform;
   platformSDK: PlatformSDK;
   udid?: string;
+  deviceName?: string;
   projectRoot: string;
 }) {
   if ('binaryPath' in args && args.binaryPath) {
@@ -54,7 +56,11 @@ export async function buildApp({
     // because running pods install might have generated .xcworkspace project.
     // This should be only case in new project.
     if (xcodeProject.isWorkspace === false) {
-      const newProjectConfig = getValidProjectConfig(platformName, projectRoot, pluginConfig);
+      const newProjectConfig = getValidProjectConfig(
+        platformName,
+        projectRoot,
+        pluginConfig
+      );
       xcodeProject = newProjectConfig.xcodeProject;
       sourceDir = newProjectConfig.sourceDir;
     }
@@ -77,6 +83,7 @@ export async function buildApp({
     scheme,
     configuration,
     args,
+    deviceName,
   });
   const buildSettings = await getBuildSettings(
     xcodeProject,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

For some reason using UDID works in some cases when using sim name with () doesn't work always, so let's use the matched device also use UDID.

### Test plan

`rnef run:ios --device "iPhone 16 Pro Max (iOS 18.4)"` should use UDID as a param in the `xcodebuild` command.