### PR TITLE
chore: improve error messages around installing pods; run codegen

### DIFF
--- a/.changeset/tough-yaks-cry.md
+++ b/.changeset/tough-yaks-cry.md
@@ -1,0 +1,7 @@
+---
+'@rnef/platform-apple-helpers': patch
+'@rnef/plugin-brownfield-ios': patch
+'@rnef/platform-ios': patch
+---
+
+chore: improve error messages around installing pods; run codegen

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -21,12 +21,19 @@ import {
 import type { BuildFlags } from './buildOptions.js';
 import { exportArchive } from './exportArchive.js';
 
-export const createBuild = async (
-  platformName: BuilderCommand['platformName'],
-  projectConfig: ProjectConfig,
-  args: BuildFlags,
-  projectRoot: string
-) => {
+export const createBuild = async ({
+  platformName,
+  projectConfig,
+  args,
+  projectRoot,
+  reactNativePath,
+}: {
+  platformName: BuilderCommand['platformName'];
+  projectConfig: ProjectConfig;
+  args: BuildFlags;
+  projectRoot: string;
+  reactNativePath: string;
+}) => {
   await validateArgs(args);
   let xcodeProject: XcodeProjectInfo;
   let sourceDir: string;
@@ -40,6 +47,7 @@ export const createBuild = async (
           ? getSimulatorPlatformSDK(platformName)
           : getDevicePlatformSDK(platformName),
       args,
+      reactNativePath,
     });
     const loader = spinner();
     loader.start('');

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -30,14 +30,23 @@ import { runOnMacCatalyst } from './runOnMacCatalyst.js';
 import { launchSimulator, runOnSimulator } from './runOnSimulator.js';
 import type { RunFlags } from './runOptions.js';
 
-export const createRun = async (
-  platformName: ApplePlatform,
-  projectConfig: ProjectConfig,
-  args: RunFlags,
-  projectRoot: string,
-  remoteCacheProvider: SupportedRemoteCacheProviders | undefined,
-  fingerprintOptions: { extraSources: string[]; ignorePaths: string[] }
-) => {
+export const createRun = async ({
+  platformName,
+  projectConfig,
+  args,
+  projectRoot,
+  remoteCacheProvider,
+  fingerprintOptions,
+  reactNativePath,
+}: {
+  platformName: ApplePlatform;
+  projectConfig: ProjectConfig;
+  args: RunFlags;
+  projectRoot: string;
+  remoteCacheProvider: SupportedRemoteCacheProviders | undefined;
+  fingerprintOptions: { extraSources: string[]; ignorePaths: string[] };
+  reactNativePath: string;
+}) => {
   if (!args.binaryPath && args.remoteCache) {
     const cachedBuild = await fetchCachedBuild({
       configuration: args.configuration ?? 'Debug',
@@ -72,6 +81,7 @@ export const createRun = async (
       projectRoot,
       udid,
       deviceName,
+      reactNativePath,
     });
     await runOnMac(appPath);
     return;
@@ -84,6 +94,7 @@ export const createRun = async (
       projectRoot,
       udid,
       deviceName,
+      reactNativePath,
     });
     if (scheme) {
       await runOnMacCatalyst(appPath, scheme);
@@ -117,6 +128,7 @@ export const createRun = async (
           platformSDK: getSimulatorPlatformSDK(platformName),
           udid: device.udid,
           projectRoot,
+          reactNativePath,
         }),
       ]);
 
@@ -129,6 +141,7 @@ export const createRun = async (
         platformSDK: getDevicePlatformSDK(platformName),
         udid: device.udid,
         projectRoot,
+        reactNativePath,
       });
       await runOnDevice(device, appPath, projectConfig.sourceDir);
     }
@@ -169,6 +182,7 @@ export const createRun = async (
           platformSDK: getSimulatorPlatformSDK(platformName),
           udid: simulator.udid,
           projectRoot,
+          reactNativePath,
         }),
       ]);
       await runOnSimulator(simulator, appPath, infoPlistPath);

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -22,6 +22,7 @@ export async function buildApp({
   udid,
   projectRoot,
   deviceName,
+  reactNativePath,
 }: {
   args: RunFlags | BuildFlags;
   projectConfig: ProjectConfig;
@@ -31,6 +32,7 @@ export async function buildApp({
   udid?: string;
   deviceName?: string;
   projectRoot: string;
+  reactNativePath: string;
 }) {
   if ('binaryPath' in args && args.binaryPath) {
     return {
@@ -50,7 +52,8 @@ export async function buildApp({
       projectRoot,
       platformName,
       sourceDir,
-      args.newArch
+      args.newArch,
+      reactNativePath
     );
     // When the project is not a workspace, we need to get the project config again,
     // because running pods install might have generated .xcworkspace project.

--- a/packages/platform-apple-helpers/src/lib/utils/codegen.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/codegen.ts
@@ -1,0 +1,41 @@
+import type { SubprocessError } from '@rnef/tools';
+import { spawn } from '@rnef/tools';
+import { RnefError } from '@rnef/tools';
+import fs from 'fs';
+import path from 'path';
+import type { ApplePlatform } from '../types/index.js';
+
+interface CodegenOptions {
+  projectRoot: string;
+  platformName: ApplePlatform;
+  reactNativePath: string;
+}
+
+async function runCodegen(options: CodegenOptions) {
+  if (fs.existsSync('build')) {
+    fs.rmSync('build', { recursive: true });
+  }
+
+  const codegenScript = path.join(
+    options.reactNativePath,
+    'scripts/generate-codegen-artifacts.js'
+  );
+
+  try {
+    await spawn('node', [
+      codegenScript,
+      '-p',
+      options.projectRoot,
+      '-o',
+      process.cwd(),
+      '-t',
+      options.platformName,
+    ]);
+  } catch (error) {
+    throw new RnefError('Failed to run React Native codegen script', {
+      cause: (error as SubprocessError).stdout,
+    });
+  }
+}
+
+export default runCodegen;

--- a/packages/platform-ios/src/lib/platformIOS.ts
+++ b/packages/platform-ios/src/lib/platformIOS.ts
@@ -24,7 +24,13 @@ export const platformIOS =
       description: 'Build iOS app.',
       action: async (args) => {
         intro('Building iOS app');
-        await createBuild('ios', iosConfig, args as BuildFlags, projectRoot);
+        await createBuild({
+          platformName: 'ios',
+          projectConfig: iosConfig,
+          args: args as BuildFlags,
+          projectRoot,
+          reactNativePath: api.getReactNativePath(),
+        });
         outro('Success 🎉.');
       },
       options: buildOptions,
@@ -35,14 +41,15 @@ export const platformIOS =
       description: 'Run iOS app.',
       action: async (args) => {
         intro('Running iOS app');
-        await createRun(
-          'ios',
-          iosConfig,
-          args as RunFlags,
+        await createRun({
+          platformName: 'ios',
+          projectConfig: iosConfig,
+          args: args as RunFlags,
           projectRoot,
-          api.getRemoteCacheProvider(),
-          api.getFingerprintOptions()
-        );
+          remoteCacheProvider: api.getRemoteCacheProvider(),
+          fingerprintOptions: api.getFingerprintOptions(),
+          reactNativePath: api.getReactNativePath(),
+        });
         outro('Success 🎉.');
       },
       // @ts-expect-error: fix `simulator` is not defined in `RunFlags`

--- a/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
+++ b/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
@@ -32,12 +32,13 @@ export const pluginBrownfieldIos =
         const buildFolder = args.buildFolder ?? derivedDataDir;
         const configuration = args.configuration ?? 'Debug';
 
-        await createBuild(
-          'ios',
-          iosConfig,
-          { ...args, destinations, buildFolder },
-          projectRoot
-        );
+        await createBuild({
+          platformName: 'ios',
+          projectConfig: iosConfig,
+          args: { ...args, destinations, buildFolder },
+          projectRoot,
+          reactNativePath: api.getReactNativePath(),
+        });
 
         if (!args.scheme) {
           throw new RnefError(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR improves a few things:

- Runs codegen script, which is necessary for RN 0.79 apps. Fixes #173 
- Removes unnecessary retry of installing pods with "pod install" – we already run "bundler install" earlier, which if passes, we should be fairly certain it will also run `bundle exec pod install`. When it fails, we want to see the error as quickly as possible instead of retrying it with "pod install" which will most likely fail with the same error
- Improves error messages around pod version failure and others
  <img width="762" alt="Screenshot 2025-04-27 at 17 12 48" src="https://github.com/user-attachments/assets/e61d941c-1e5e-47df-96bf-a158412bf00f" />
 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
