### PR TITLE
fix: run codegen script in sourceDir

### DIFF
--- a/.changeset/plenty-cooks-eat.md
+++ b/.changeset/plenty-cooks-eat.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: run codegen script in sourceDir

--- a/packages/platform-apple-helpers/src/lib/utils/codegen.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/codegen.ts
@@ -9,11 +9,13 @@ interface CodegenOptions {
   projectRoot: string;
   platformName: ApplePlatform;
   reactNativePath: string;
+  sourceDir: string;
 }
 
 async function runCodegen(options: CodegenOptions) {
-  if (fs.existsSync('build')) {
-    fs.rmSync('build', { recursive: true });
+  const buildDir = path.join(options.sourceDir, 'build');
+  if (fs.existsSync(buildDir)) {
+    fs.rmSync(buildDir, { recursive: true });
   }
 
   const codegenScript = path.join(
@@ -27,7 +29,7 @@ async function runCodegen(options: CodegenOptions) {
       '-p',
       options.projectRoot,
       '-o',
-      process.cwd(),
+      options.sourceDir,
       '-t',
       options.platformName,
     ]);

--- a/packages/platform-apple-helpers/src/lib/utils/pods.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/pods.ts
@@ -42,7 +42,7 @@ export async function installPodsIfNeeded(
     : true;
 
   if (!podsDirExists || hashChanged) {
-    await runCodegen({ projectRoot, platformName, reactNativePath });
+    await runCodegen({ projectRoot, platformName, reactNativePath, sourceDir });
     await installPods({ projectRoot, sourceDir, podfilePath, newArch });
     cacheManager.set(
       cacheKey,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a bug where `build/generated/ios` folder for codegen would be generated inside root project instead of in `sourceDir`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
