### PR TITLE
fix: skip hidden files when finding binary path

### DIFF
--- a/.changeset/good-ants-look.md
+++ b/.changeset/good-ants-look.md
@@ -1,0 +1,5 @@
+---
+'@rnef/tools': patch
+---
+
+fix: skip hidden files when finding binary path

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -68,10 +68,14 @@ export function getLocalBinaryPath(artifactPath: string) {
 
   // assume there is only one binary in the artifact
   for (const file of files) {
+    // skip hidden files such as .DS_Store
+    if (file.startsWith('.')) {
+      continue;
+    }
     if (file) {
       binaryPath = path.join(artifactPath, file);
+      break;
     }
-    break;
   }
 
   return binaryPath;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Workaround for `.DS_Store` files

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
