### PR TITLE
WIP feat: allow running dev server from run commands

### DIFF
--- a/packages/config/src/lib/config.ts
+++ b/packages/config/src/lib/config.ts
@@ -11,6 +11,21 @@ export type PluginOutput = {
   description: string;
 };
 
+type StartDevServerFunction = (options: {
+  root: string;
+  // TODO fix type
+  args: any;
+  reactNativeVersion: string;
+  reactNativePath: string;
+  platforms: Record<string, object>;
+}) => Promise<void>;
+
+export type BundlerPluginOutput = {
+  name: string;
+  description: string;
+  start: StartDevServerFunction;
+};
+
 export type PlatformOutput = PluginOutput & {
   autolinkingConfig: { project: Record<string, unknown> | undefined };
 };
@@ -26,12 +41,13 @@ export type PluginApi = {
     extraSources: string[];
     ignorePaths: string[];
   };
+  getBundlerStart: () => ({ args: any }) => Promise<void>;
 };
 
 type SupportedRemoteCacheProviders = 'github-actions';
 
 type PluginType = (args: PluginApi) => PluginOutput;
-
+type BundlerPluginType = (args: PluginApi) => BundlerPluginOutput;
 type PlatformType = (args: PluginApi) => PlatformOutput;
 
 type ArgValue = string | string[] | number | boolean;
@@ -64,7 +80,7 @@ export type ConfigType = {
   root?: string;
   reactNativeVersion?: string;
   reactNativePath?: string;
-  bundler?: PluginType;
+  bundler?: BundlerPluginType;
   plugins?: PluginType[];
   platforms?: Record<string, PlatformType>;
   commands?: Array<CommandType>;
@@ -165,11 +181,22 @@ export async function getConfig(dir: string): Promise<ConfigOutput> {
         extraSources: string[];
         ignorePaths: string[];
       },
+    getBundlerStart:
+      () =>
+      ({ args: any }) =>
+        bundler?.start({
+          root: api.getProjectRoot(),
+          args,
+          reactNativeVersion: api.getReactNativeVersion(),
+          reactNativePath: api.getReactNativePath(),
+          platforms: api.getPlatforms(),
+        }),
   };
 
   if (validatedConfig.plugins) {
     // plugins register commands
     for (const plugin of validatedConfig.plugins) {
+      // @ts-expect-error tbd
       assignOriginToCommand(plugin, api, validatedConfig);
     }
   }
@@ -178,15 +205,24 @@ export async function getConfig(dir: string): Promise<ConfigOutput> {
   if (validatedConfig.platforms) {
     // platforms register commands and custom platform functionality (TBD)
     for (const platform in validatedConfig.platforms) {
+      // @ts-expect-error tbd
       const platformOutput = validatedConfig.platforms[platform](api);
       platforms[platform] = platformOutput;
     }
   }
 
+  let bundler: BundlerPluginOutput | undefined;
   if (validatedConfig.bundler) {
-    assignOriginToCommand(validatedConfig.bundler, api, validatedConfig);
+    // @ts-expect-error tbd
+    bundler = assignOriginToCommand(
+      validatedConfig.bundler,
+      // @ts-expect-error tbd
+      api,
+      validatedConfig
+    );
   }
 
+  // @ts-expect-error tbd
   const outputConfig: ConfigOutput = {
     root: projectRoot,
     commands: validatedConfig.commands ?? [],
@@ -225,16 +261,17 @@ function resolveReactNativePath(root: string) {
  * Assigns __origin property to each command in the config for later use in error handling.
  */
 function assignOriginToCommand(
-  plugin: PluginType,
+  plugin: PluginType | BundlerPluginType,
   api: PluginApi,
   config: ConfigType
 ) {
   const len = config.commands?.length ?? 0;
-  const { name } = plugin(api);
+  const { name, ...rest } = plugin(api);
   const newlen = config.commands?.length ?? 0;
   for (let i = len; i < newlen; i++) {
     if (config.commands?.[i]) {
       config.commands[i].__origin = name;
     }
   }
+  return { name, ...rest };
 }

--- a/packages/platform-android/src/lib/commands/runAndroid/command.ts
+++ b/packages/platform-android/src/lib/commands/runAndroid/command.ts
@@ -18,7 +18,8 @@ export function registerRunCommand(
         args as Flags,
         projectRoot,
         api.getRemoteCacheProvider(),
-        api.getFingerprintOptions()
+        api.getFingerprintOptions(),
+        api.getBundlerStart()
       );
     },
     options: runOptions,

--- a/packages/platform-android/src/lib/commands/runAndroid/runAndroid.ts
+++ b/packages/platform-android/src/lib/commands/runAndroid/runAndroid.ts
@@ -47,7 +47,15 @@ export async function runAndroid(
   args: Flags,
   projectRoot: string,
   remoteCacheProvider: SupportedRemoteCacheProviders | undefined,
-  fingerprintOptions: { extraSources: string[]; ignorePaths: string[] }
+  fingerprintOptions: { extraSources: string[]; ignorePaths: string[] },
+  startDevServer: (options: {
+    root: string;
+    // TODO fix type
+    args: any;
+    reactNativeVersion: string;
+    reactNativePath: string;
+    platforms: Record<string, object>;
+  }) => Promise<void>
 ) {
   intro('Running Android app');
 
@@ -97,6 +105,14 @@ export async function runAndroid(
         await tryLaunchEmulator();
       }
     }
+    console.log('xd');
+    startDevServer({
+      root: projectRoot,
+      reactNativePath: './node_modules/react-native',
+      reactNativeVersion: '0.79',
+      platforms: { ios: {}, android: {} },
+      args,
+    });
 
     await runGradle({ tasks, androidProject, args });
 

--- a/packages/plugin-metro/src/index.ts
+++ b/packages/plugin-metro/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/pluginMetro.js';
+export { startDevServer } from './lib/start/command.js';

--- a/packages/plugin-metro/src/lib/pluginMetro.ts
+++ b/packages/plugin-metro/src/lib/pluginMetro.ts
@@ -1,16 +1,17 @@
-import type { PluginApi, PluginOutput } from '@rnef/config';
+import type { BundlerPluginOutput, PluginApi } from '@rnef/config';
 import { registerBundleCommand } from './bundle/command.js';
-import { registerStartCommand } from './start/command.js';
+import { registerStartCommand, startDevServer } from './start/command.js';
 
 export const pluginMetro =
   () =>
-  (api: PluginApi): PluginOutput => {
+  (api: PluginApi): BundlerPluginOutput => {
     registerStartCommand(api);
     registerBundleCommand(api);
 
     return {
       name: '@rnef/plugin-metro',
       description: 'RNEF plugin for Metro bundler.',
+      start: startDevServer,
     };
   };
 

--- a/packages/plugin-metro/src/lib/start/command.ts
+++ b/packages/plugin-metro/src/lib/start/command.ts
@@ -11,33 +11,50 @@ import { findDevServerPort, intro } from '@rnef/tools';
 import type { StartCommandArgs } from './runServer.js';
 import runServer from './runServer.js';
 
+export async function startDevServer({
+  root,
+  args,
+  reactNativeVersion,
+  reactNativePath,
+  platforms,
+}: {
+  root: string;
+  args: StartCommandArgs;
+  reactNativeVersion: string;
+  reactNativePath: string;
+  platforms: Record<string, object>;
+}) {
+  const { port, startDevServer } = await findDevServerPort(
+    args.port ?? 8081,
+    root
+  );
+
+  if (!startDevServer) {
+    return;
+  }
+
+  return runServer(
+    { root, reactNativeVersion, reactNativePath, platforms },
+    { ...args, port }
+  );
+}
+
 export const registerStartCommand = (api: PluginApi) => {
   api.registerCommand({
     name: 'start',
     action: async (args: StartCommandArgs) => {
       intro('Starting Metro dev server');
       const root = api.getProjectRoot();
-      const { port, startDevServer } = await findDevServerPort(
-        args.port ?? 8081,
-        root
-      );
-
-      if (!startDevServer) {
-        return;
-      }
-
       const reactNativeVersion = api.getReactNativeVersion();
       const reactNativePath = api.getReactNativePath();
       const platforms = api.getPlatforms();
-      return runServer(
-        {
-          root,
-          reactNativeVersion,
-          reactNativePath,
-          platforms,
-        },
-        { ...args, port }
-      );
+      await startDevServer({
+        root,
+        args,
+        reactNativeVersion,
+        reactNativePath,
+        platforms,
+      });
     },
     description: 'Start the Metro development server.',
     options: [


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

While running `run:android` or `run:ios` we should be able to start a dev server and keep it open after the build is done

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
