### PR TITLE
Update ios.md

### DIFF
--- a/website/docs/docs/brownfield/ios.md
+++ b/website/docs/docs/brownfield/ios.md
@@ -75,7 +75,7 @@ To add React Native to your iOS app, we'll package your React Native code into a
 1. Open Terminal and run:
 
    ```sh title="Terminal"
-   rnef package:ios --scheme <framework_target_name> --mode Release
+   rnef package:ios --scheme <framework_target_name> --configuration Release
    ```
 
 ## 6. Add the Framework to Your App:


### PR DESCRIPTION
fix package:ios commande

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Based on help command, we should use `--configuration ` instead of `--mode`

```
npx rnef package:ios --help
Usage: rnef package:ios [options]

Emit a .xcframework file from React Native code.

Options:
  --verbose
  --configuration <string>         Explicitly set the scheme configuration to use. This
                                   option is case sensitive.
```

### Test plan

none
