### PR TITLE
fix: lazy load autolinking platform config

### DIFF
--- a/.changeset/late-students-allow.md
+++ b/.changeset/late-students-allow.md
@@ -1,0 +1,7 @@
+---
+'@rnef/plugin-brownfield-ios': patch
+'@rnef/platform-android': patch
+'@rnef/platform-ios': patch
+---
+
+fix: lazy load autolinking platform config

--- a/packages/platform-android/src/lib/commands/buildAndroid/command.ts
+++ b/packages/platform-android/src/lib/commands/buildAndroid/command.ts
@@ -1,16 +1,21 @@
 import type { AndroidProjectConfig } from '@react-native-community/cli-types';
 import type { PluginApi } from '@rnef/config';
+import { getValidProjectConfig } from '../getValidProjectConfig.js';
 import type { BuildFlags } from './buildAndroid.js';
 import { buildAndroid, options } from './buildAndroid.js';
 
 export function registerBuildCommand(
   api: PluginApi,
-  androidConfig: AndroidProjectConfig
+  pluginConfig: AndroidProjectConfig | undefined
 ) {
   api.registerCommand({
     name: 'build:android',
     description: 'Builds your app for Android platform.',
     action: async (args) => {
+      const androidConfig = getValidProjectConfig(
+        api.getProjectRoot(),
+        pluginConfig
+      );
       await buildAndroid(androidConfig, args as BuildFlags);
     },
     options: options,

--- a/packages/platform-android/src/lib/commands/generateKeystore.ts
+++ b/packages/platform-android/src/lib/commands/generateKeystore.ts
@@ -12,15 +12,20 @@ import {
   RnefError,
   spawn,
 } from '@rnef/tools';
+import { getValidProjectConfig } from './getValidProjectConfig.js';
 
 export function registerCreateKeystoreCommand(
   api: PluginApi,
-  androidConfig: AndroidProjectConfig
+  pluginConfig: AndroidProjectConfig | undefined
 ) {
   api.registerCommand({
     name: 'create-keystore:android',
     description: 'Creates a keystore file for signing Android release builds.',
     action: async (args) => {
+      const androidConfig = getValidProjectConfig(
+        api.getProjectRoot(),
+        pluginConfig
+      );
       await generateKeystore(androidConfig, args);
     },
     options: generateKeystoreOptions,

--- a/packages/platform-android/src/lib/commands/runAndroid/command.ts
+++ b/packages/platform-android/src/lib/commands/runAndroid/command.ts
@@ -1,11 +1,12 @@
 import type { AndroidProjectConfig } from '@react-native-community/cli-types';
 import type { PluginApi } from '@rnef/config';
+import { getValidProjectConfig } from '../getValidProjectConfig.js';
 import type { Flags } from './runAndroid.js';
 import { runAndroid, runOptions } from './runAndroid.js';
 
 export function registerRunCommand(
   api: PluginApi,
-  androidConfig: AndroidProjectConfig
+  pluginConfig: AndroidProjectConfig | undefined
 ) {
   api.registerCommand({
     name: 'run:android',
@@ -13,6 +14,7 @@ export function registerRunCommand(
       'Builds your app and starts it on a connected Android emulator or a device.',
     action: async (args) => {
       const projectRoot = api.getProjectRoot();
+      const androidConfig = getValidProjectConfig(projectRoot, pluginConfig);
       await runAndroid(
         androidConfig,
         args as Flags,

--- a/packages/platform-android/src/lib/platformAndroid.ts
+++ b/packages/platform-android/src/lib/platformAndroid.ts
@@ -11,19 +11,23 @@ type PluginConfig = AndroidProjectConfig;
 export const platformAndroid =
   (pluginConfig?: PluginConfig) =>
   (api: PluginApi): PlatformOutput => {
-    const androidConfig = getValidProjectConfig(
-      api.getProjectRoot(),
-      pluginConfig
-    );
-    registerBuildCommand(api, androidConfig);
-    registerRunCommand(api, androidConfig);
-    registerCreateKeystoreCommand(api, androidConfig);
+    registerBuildCommand(api, pluginConfig);
+    registerRunCommand(api, pluginConfig);
+    registerCreateKeystoreCommand(api, pluginConfig);
     registerSignCommand(api);
 
     return {
       name: '@rnef/platform-android',
       description: 'RNEF plugin for everything Android.',
-      autolinkingConfig: { project: { ...androidConfig } },
+      autolinkingConfig: {
+        get project() {
+          const androidConfig = getValidProjectConfig(
+            api.getProjectRoot(),
+            pluginConfig
+          );
+          return { ...androidConfig };
+        },
+      },
     };
   };
 

--- a/packages/platform-ios/src/lib/platformIOS.ts
+++ b/packages/platform-ios/src/lib/platformIOS.ts
@@ -17,13 +17,17 @@ const runOptions = getRunOptions({ platformName: 'ios' });
 export const platformIOS =
   (pluginConfig?: IOSProjectConfig) =>
   (api: PluginApi): PlatformOutput => {
-    const projectRoot = api.getProjectRoot();
-    const iosConfig = getValidProjectConfig('ios', projectRoot, pluginConfig);
     api.registerCommand({
       name: 'build:ios',
       description: 'Build iOS app.',
       action: async (args) => {
         intro('Building iOS app');
+        const projectRoot = api.getProjectRoot();
+        const iosConfig = getValidProjectConfig(
+          'ios',
+          projectRoot,
+          pluginConfig
+        );
         await createBuild({
           platformName: 'ios',
           projectConfig: iosConfig,
@@ -41,6 +45,12 @@ export const platformIOS =
       description: 'Run iOS app.',
       action: async (args) => {
         intro('Running iOS app');
+        const projectRoot = api.getProjectRoot();
+        const iosConfig = getValidProjectConfig(
+          'ios',
+          projectRoot,
+          pluginConfig
+        );
         await createRun({
           platformName: 'ios',
           projectConfig: iosConfig,
@@ -61,7 +71,16 @@ export const platformIOS =
     return {
       name: '@rnef/platform-ios',
       description: 'RNEF plugin for everything iOS.',
-      autolinkingConfig: { project: { ...iosConfig } },
+      autolinkingConfig: {
+        get project() {
+          const iosConfig = getValidProjectConfig(
+            'ios',
+            api.getProjectRoot(),
+            pluginConfig
+          );
+          return { ...iosConfig };
+        },
+      },
     };
   };
 

--- a/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
+++ b/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
@@ -21,7 +21,11 @@ export const pluginBrownfieldIos =
         intro('Packaging iOS project');
 
         const projectRoot = api.getProjectRoot();
-        const iosConfig = getValidProjectConfig('ios', projectRoot, pluginConfig);
+        const iosConfig = getValidProjectConfig(
+          'ios',
+          projectRoot,
+          pluginConfig
+        );
         const { derivedDataDir } = getBuildPaths('ios');
 
         const destinations = args.destinations ?? [
@@ -32,6 +36,12 @@ export const pluginBrownfieldIos =
         const buildFolder = args.buildFolder ?? derivedDataDir;
         const configuration = args.configuration ?? 'Debug';
 
+        if (!args.scheme) {
+          throw new RnefError(
+            'Scheme is required. Please provide "--scheme" flag.'
+          );
+        }
+
         await createBuild({
           platformName: 'ios',
           projectConfig: iosConfig,
@@ -39,12 +49,6 @@ export const pluginBrownfieldIos =
           projectRoot,
           reactNativePath: api.getReactNativePath(),
         });
-
-        if (!args.scheme) {
-          throw new RnefError(
-            'Scheme is required. Please provide "--scheme" flag.'
-          );
-        }
 
         await mergeFrameworks({
           scheme: args.scheme,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Loading iOS platform config when Android commands are run and vice-versa is unnecessary. This PR ads lazy loading to reading platform project config for auto linking purposes

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
