### PR TITLE
feat: official support for custom remote cache providers

### DIFF
--- a/.changeset/large-mirrors-confess.md
+++ b/.changeset/large-mirrors-confess.md
@@ -1,0 +1,7 @@
+---
+'@rnef/config': patch
+'@rnef/tools': patch
+'rnef-docs': patch
+---
+
+feat: official support for custom remote cache providers

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -40,9 +40,11 @@ const ConfigTypeSchema = Joi.object({
   plugins: Joi.array().items(Joi.function()).optional(),
   platforms: Joi.object().pattern(Joi.string(), Joi.function()).optional(),
   commands: Joi.array().items(CommandTypeSchema).optional(),
-  remoteCacheProvider: Joi.string()
-    .valid('github-actions', null, Joi.function())
-    .optional(),
+  remoteCacheProvider: Joi.alternatives().try(
+    Joi.string().valid('github-actions'),
+    Joi.function(),
+    Joi.any().valid(null)
+  ).optional(),
   fingerprint: Joi.object({
     extraSources: Joi.array().items(Joi.string()).default([]),
     ignorePaths: Joi.array().items(Joi.string()).default([]),

--- a/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
+++ b/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
@@ -1,25 +1,28 @@
 import { expect, test } from 'vitest';
-import type {
-  RemoteArtifact,
-  RemoteBuildCache,
-} from '../build-cache/common.js';
+import type { RemoteBuildCache } from '../build-cache/common.js';
 import { createRemoteBuildCache } from '../build-cache/remoteBuildCache.js';
 
 const uploadMock = vi.fn();
 
 class DummyRemoteCacheProvider implements RemoteBuildCache {
   name = 'dummy';
+  constructor(options?: { name: string }) {
+    if (options) {
+      this.name = options.name;
+    }
+  }
   async list({ artifactName }: { artifactName: string }) {
     return [{ name: artifactName, url: '/path/to/dummy' }];
   }
-  async download({ artifact }: { artifact: RemoteArtifact }) {
-    return { name: artifact.name };
+  async download({ artifactName }: { artifactName: string }) {
+    const resBody = new TextEncoder().encode(artifactName);
+    return new Response(resBody);
   }
-  async delete({ artifact }: { artifact: RemoteArtifact }) {
-    if (artifact.name === 'dummy') {
-      return true;
+  async delete({ artifactName }: { artifactName: string }) {
+    if (artifactName === 'dummy') {
+      return [{ name: artifactName, url: '/path/to/dummy' }];
     }
-    return false;
+    return [];
   }
   async upload({ artifactName }: { artifactName: string }) {
     uploadMock(artifactName);
@@ -28,8 +31,10 @@ class DummyRemoteCacheProvider implements RemoteBuildCache {
 }
 
 test('dummy remote cache provider lists artifacts', async () => {
+  const pluginDummyRemoteCacheProvider = (options?: { name: string }) => () =>
+    new DummyRemoteCacheProvider(options);
   const remoteBuildCache = await createRemoteBuildCache(
-    DummyRemoteCacheProvider
+    pluginDummyRemoteCacheProvider()
   );
   const artifacts = await remoteBuildCache?.list({
     artifactName: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
@@ -43,43 +48,43 @@ test('dummy remote cache provider lists artifacts', async () => {
 });
 
 test('dummy remote cache provider downloads artifacts', async () => {
+  const pluginDummyRemoteCacheProvider = (options?: { name: string }) => () =>
+    new DummyRemoteCacheProvider(options);
   const remoteBuildCache = await createRemoteBuildCache(
-    DummyRemoteCacheProvider
+    pluginDummyRemoteCacheProvider()
   );
   const artifact = await remoteBuildCache?.download({
-    artifact: {
-      name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
-      url: '/path/to/dummy',
-    },
-    targetURL: new URL(
-      'file:///cache/path/rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4'
-    ),
+    artifactName: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
   });
-  expect(artifact).toEqual({
-    name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
-  });
+  const response = await artifact?.text();
+  expect(response).toEqual(
+    'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4'
+  );
 });
 
 test('dummy remote cache provider deletes artifacts', async () => {
+  const pluginDummyRemoteCacheProvider = (options?: { name: string }) => () =>
+    new DummyRemoteCacheProvider(options);
   const remoteBuildCache = await createRemoteBuildCache(
-    DummyRemoteCacheProvider
+    pluginDummyRemoteCacheProvider()
   );
-  const result = await remoteBuildCache?.delete({
-    artifact: { name: 'dummy', url: '/path/to/dummy' },
-  });
-  expect(result).toEqual(true);
-  const result2 = await remoteBuildCache?.delete({
-    artifact: { name: 'dummy2', url: '/path/to/dummy2' },
-  });
-  expect(result2).toEqual(false);
+  const result = await remoteBuildCache?.delete({ artifactName: 'dummy' });
+  expect(result).toEqual([
+    {
+      name: 'dummy',
+      url: '/path/to/dummy',
+    },
+  ]);
+  const result2 = await remoteBuildCache?.delete({ artifactName: 'dummy2' });
+  expect(result2).toEqual([]);
 });
 
 test('dummy remote cache provider uploads artifacts', async () => {
+  const pluginDummyRemoteCacheProvider = (options?: { name: string }) => () =>
+    new DummyRemoteCacheProvider(options);
   const remoteBuildCache = await createRemoteBuildCache(
-    DummyRemoteCacheProvider
+    pluginDummyRemoteCacheProvider()
   );
-  await remoteBuildCache?.upload({
-    artifactName: 'dummy',
-  });
+  await remoteBuildCache?.upload({ artifactName: 'dummy' });
   expect(uploadMock).toHaveBeenCalledWith('dummy');
 });

--- a/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
+++ b/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+import type {
+  RemoteArtifact,
+  RemoteBuildCache,
+} from '../build-cache/common.js';
+import { createRemoteBuildCache } from '../build-cache/remoteBuildCache.js';
+
+const uploadMock = vi.fn();
+
+class DummyRemoteCacheProvider implements RemoteBuildCache {
+  name = 'dummy';
+  async list({ artifactName }: { artifactName: string }) {
+    return [{ name: artifactName, url: '/path/to/dummy' }];
+  }
+  async download({ artifact }: { artifact: RemoteArtifact }) {
+    return { name: artifact.name, path: artifact.url };
+  }
+  async delete({ artifactName }: { artifactName: string }) {
+    if (artifactName === 'dummy') {
+      return true;
+    }
+    return false;
+  }
+  async upload({
+    artifactPath,
+    artifactName,
+  }: {
+    artifactPath: string;
+    artifactName: string;
+  }) {
+    uploadMock(artifactPath, artifactName);
+    return null;
+  }
+}
+
+test('dummy remote cache provider lists artifacts', async () => {
+  const remoteBuildCache = await createRemoteBuildCache(
+    DummyRemoteCacheProvider
+  );
+  const artifacts = await remoteBuildCache?.list({
+    artifactName: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
+  });
+  expect(artifacts).toEqual([
+    {
+      name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
+      url: '/path/to/dummy',
+    },
+  ]);
+});
+
+test('dummy remote cache provider downloads artifacts', async () => {
+  const remoteBuildCache = await createRemoteBuildCache(
+    DummyRemoteCacheProvider
+  );
+  const artifact = await remoteBuildCache?.download({
+    artifact: {
+      name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
+      url: '/path/to/dummy',
+    },
+  });
+  expect(artifact).toEqual({
+    name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
+    path: '/path/to/dummy',
+  });
+});
+
+test('dummy remote cache provider deletes artifacts', async () => {
+  const remoteBuildCache = await createRemoteBuildCache(
+    DummyRemoteCacheProvider
+  );
+  const result = await remoteBuildCache?.delete({ artifactName: 'dummy' });
+  expect(result).toEqual(true);
+  const result2 = await remoteBuildCache?.delete({ artifactName: 'dummy2' });
+  expect(result2).toEqual(false);
+});
+
+test('dummy remote cache provider uploads artifacts', async () => {
+  const remoteBuildCache = await createRemoteBuildCache(
+    DummyRemoteCacheProvider
+  );
+  await remoteBuildCache?.upload({
+    artifactPath: '/path/to/dummy',
+    artifactName: 'dummy',
+  });
+  expect(uploadMock).toHaveBeenCalledWith('/path/to/dummy', 'dummy');
+});

--- a/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
+++ b/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
@@ -24,7 +24,7 @@ class DummyRemoteCacheProvider implements RemoteBuildCache {
   }
   async upload({ artifact }: { artifact: LocalArtifact }) {
     uploadMock(artifact.path, artifact.name);
-    return null;
+    return { name: artifact.name, url: '/path/to/dummy' };
   }
 }
 

--- a/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
+++ b/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'vitest';
 import type {
-  LocalArtifact,
   RemoteArtifact,
   RemoteBuildCache,
 } from '../build-cache/common.js';
@@ -14,7 +13,7 @@ class DummyRemoteCacheProvider implements RemoteBuildCache {
     return [{ name: artifactName, url: '/path/to/dummy' }];
   }
   async download({ artifact }: { artifact: RemoteArtifact }) {
-    return { name: artifact.name, path: artifact.url };
+    return { name: artifact.name };
   }
   async delete({ artifact }: { artifact: RemoteArtifact }) {
     if (artifact.name === 'dummy') {
@@ -22,9 +21,9 @@ class DummyRemoteCacheProvider implements RemoteBuildCache {
     }
     return false;
   }
-  async upload({ artifact }: { artifact: LocalArtifact }) {
-    uploadMock(artifact.path, artifact.name);
-    return { name: artifact.name, url: '/path/to/dummy' };
+  async upload({ artifactName }: { artifactName: string }) {
+    uploadMock(artifactName);
+    return { name: artifactName, url: '/path/to/dummy' };
   }
 }
 
@@ -52,10 +51,12 @@ test('dummy remote cache provider downloads artifacts', async () => {
       name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
       url: '/path/to/dummy',
     },
+    targetURL: new URL(
+      'file:///cache/path/rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4'
+    ),
   });
   expect(artifact).toEqual({
     name: 'rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4',
-    path: '/path/to/dummy',
   });
 });
 
@@ -78,7 +79,7 @@ test('dummy remote cache provider uploads artifacts', async () => {
     DummyRemoteCacheProvider
   );
   await remoteBuildCache?.upload({
-    artifact: { path: '/path/to/dummy', name: 'dummy' },
+    artifactName: 'dummy',
   });
-  expect(uploadMock).toHaveBeenCalledWith('/path/to/dummy', 'dummy');
+  expect(uploadMock).toHaveBeenCalledWith('dummy');
 });

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -11,7 +11,6 @@ export type SupportedRemoteCacheProviders = 'github-actions';
 export type RemoteArtifact = {
   name: string;
   url: string;
-  id?: string;
 };
 
 export type LocalArtifact = {

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -73,7 +73,7 @@ export interface RemoteBuildCache {
    * Upload a local artifact to remote storage
    * @param artifact - Local artifact to upload, as returned by `download` method
    * @param loader - Optional progress indicator
-   * @returns Remote artifact info if upload successful, null otherwise
+   * @returns Remote artifact info if upload successful, throws otherwise
    */
   upload({
     artifact,
@@ -81,7 +81,7 @@ export interface RemoteBuildCache {
   }: {
     artifact: LocalArtifact;
     loader?: ReturnType<typeof spinner>;
-  }): Promise<RemoteArtifact | null>;
+  }): Promise<RemoteArtifact>;
 }
 
 /**

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { nativeFingerprint } from '../fingerprint/index.js';
 import { getCacheRootPath } from '../project.js';
-import type { spinner } from '../prompts.js';
 
 export const BUILD_CACHE_DIR = 'remote-build';
 
@@ -42,48 +41,24 @@ export interface RemoteBuildCache {
 
   /**
    * Download a remote artifact to local storage
-   * @param artifact - Remote artifact to download, as returned by `list` method
-   * @param targetURL - Local file URL to download the artifact to
-   * @param loader - Optional progress indicator
-   * @returns Local artifact info after download
+   * @param artifactName - Name of the artifact to download, e.g. `rnef-android-debug-1234567890` for android in debug variant
+   * @returns Response object from fetch, which will be used to download the artifact
    */
-  download({
-    artifact,
-    targetURL,
-    loader,
-  }: {
-    artifact: RemoteArtifact;
-    targetURL: URL;
-    loader?: ReturnType<typeof spinner>;
-  }): Promise<LocalArtifact>;
+  download({ artifactName }: { artifactName: string }): Promise<Response>;
 
   /**
    * Delete a remote artifact
    * @param artifact - Remote artifact to delete, as returned by `list` method
-   * @param loader - Optional progress indicator
-   * @returns True if deletion was successful
+   * Throws if artifact is not found or deletion fails
    */
-  delete({
-    artifact,
-    loader,
-  }: {
-    artifact: RemoteArtifact;
-    loader?: ReturnType<typeof spinner>;
-  }): Promise<boolean>;
+  delete({ artifactName }: { artifactName: string }): Promise<RemoteArtifact[]>;
 
   /**
    * Upload a local artifact stored in build cache to remote storage
    * @param artifactName - Name of the artifact to upload, e.g. `rnef-android-debug-1234567890` for android in debug variant
-   * @param loader - Optional progress indicator
    * @returns Remote artifact info if upload successful, throws otherwise
    */
-  upload({
-    artifactName,
-    loader,
-  }: {
-    artifactName: string;
-    loader?: ReturnType<typeof spinner>;
-  }): Promise<RemoteArtifact>;
+  upload({ artifactName }: { artifactName: string }): Promise<RemoteArtifact>;
 }
 
 /**

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -19,8 +19,21 @@ export type LocalArtifact = {
   path: string;
 };
 
+/**
+ * Interface for implementing remote build cache providers.
+ * Remote cache providers allow storing and retrieving native build artifacts (e.g. APK, IPA)
+ * from remote storage like S3, GitHub Artifacts etc.
+ */
 export interface RemoteBuildCache {
+  /** Unique identifier for this cache provider, will be displayed in logs */
   name: string;
+
+  /**
+   * List available artifacts matching the given name pattern
+   * @param artifactName - Passed after fingerprinting the build, e.g. `rnef-android-debug-1234567890` for android in debug variant
+   * @param limit - Optional maximum number of artifacts to return
+   * @returns Array of matching remote artifacts, or null if none found
+   */
   list({
     artifactName,
     limit,
@@ -28,6 +41,13 @@ export interface RemoteBuildCache {
     artifactName: string | undefined;
     limit?: number;
   }): Promise<RemoteArtifact[] | null>;
+
+  /**
+   * Download a remote artifact to local storage
+   * @param artifact - Remote artifact to download, as returned by `list` method
+   * @param loader - Optional progress indicator
+   * @returns Local artifact info after download
+   */
   download({
     artifact,
     loader,
@@ -35,20 +55,32 @@ export interface RemoteBuildCache {
     artifact: RemoteArtifact;
     loader?: ReturnType<typeof spinner>;
   }): Promise<LocalArtifact>;
+
+  /**
+   * Delete a remote artifact
+   * @param artifact - Remote artifact to delete, as returned by `list` method
+   * @param loader - Optional progress indicator
+   * @returns True if deletion was successful
+   */
   delete({
-    artifactName,
+    artifact,
     loader,
   }: {
-    artifactName: string;
+    artifact: RemoteArtifact;
     loader?: ReturnType<typeof spinner>;
   }): Promise<boolean>;
+
+  /**
+   * Upload a local artifact to remote storage
+   * @param artifact - Local artifact to upload, as returned by `download` method
+   * @param loader - Optional progress indicator
+   * @returns Remote artifact info if upload successful, null otherwise
+   */
   upload({
-    artifactPath,
-    artifactName,
+    artifact,
     loader,
   }: {
-    artifactPath: string;
-    artifactName: string;
+    artifact: LocalArtifact;
     loader?: ReturnType<typeof spinner>;
   }): Promise<RemoteArtifact | null>;
 }

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -49,14 +49,16 @@ export interface RemoteBuildCache {
   /**
    * Delete a remote artifact
    * @param artifact - Remote artifact to delete, as returned by `list` method
-   * Throws if artifact is not found or deletion fails
+   * @returns Array of deleted artifacts
+   * @throws {Error} Throws if artifact is not found or deletion fails
    */
   delete({ artifactName }: { artifactName: string }): Promise<RemoteArtifact[]>;
 
   /**
    * Upload a local artifact stored in build cache to remote storage
    * @param artifactName - Name of the artifact to upload, e.g. `rnef-android-debug-1234567890` for android in debug variant
-   * @returns Remote artifact info if upload successful, throws otherwise
+   * @returns Remote artifact info if upload successful
+   * @throws {Error} Throws if upload fails
    */
   upload({ artifactName }: { artifactName: string }): Promise<RemoteArtifact>;
 }

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -11,7 +11,7 @@ export type SupportedRemoteCacheProviders = 'github-actions';
 export type RemoteArtifact = {
   name: string;
   url: string;
-  id: string;
+  id?: string;
 };
 
 export type LocalArtifact = {

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -91,7 +91,7 @@ export function getLocalArtifactPath(artifactName: string) {
 
 export function getLocalBinaryPath(artifactPath: string) {
   const files = fs.readdirSync(artifactPath);
-  // Get the first non-hidden file as the binary
+  // Get the first non-hidden, non-directory file as the binary
   const binaryName = files.find((file) => file && !file.startsWith('.'));
   return binaryName ? path.join(artifactPath, binaryName) : null;
 }

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -32,7 +32,7 @@ export interface RemoteBuildCache {
    * List available artifacts matching the given name pattern
    * @param artifactName - Passed after fingerprinting the build, e.g. `rnef-android-debug-1234567890` for android in debug variant
    * @param limit - Optional maximum number of artifacts to return
-   * @returns Array of matching remote artifacts, or null if none found
+   * @returns Array of matching remote artifacts, or empty array if none found
    */
   list({
     artifactName,
@@ -40,7 +40,7 @@ export interface RemoteBuildCache {
   }: {
     artifactName: string | undefined;
     limit?: number;
-  }): Promise<RemoteArtifact[] | null>;
+  }): Promise<RemoteArtifact[]>;
 
   /**
    * Download a remote artifact to local storage

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -15,7 +15,6 @@ export type RemoteArtifact = {
 
 export type LocalArtifact = {
   name: string;
-  path: string;
 };
 
 /**
@@ -44,14 +43,17 @@ export interface RemoteBuildCache {
   /**
    * Download a remote artifact to local storage
    * @param artifact - Remote artifact to download, as returned by `list` method
+   * @param targetURL - Local file URL to download the artifact to
    * @param loader - Optional progress indicator
    * @returns Local artifact info after download
    */
   download({
     artifact,
+    targetURL,
     loader,
   }: {
     artifact: RemoteArtifact;
+    targetURL: URL;
     loader?: ReturnType<typeof spinner>;
   }): Promise<LocalArtifact>;
 
@@ -70,16 +72,16 @@ export interface RemoteBuildCache {
   }): Promise<boolean>;
 
   /**
-   * Upload a local artifact to remote storage
-   * @param artifact - Local artifact to upload, as returned by `download` method
+   * Upload a local artifact stored in build cache to remote storage
+   * @param artifactName - Name of the artifact to upload, e.g. `rnef-android-debug-1234567890` for android in debug variant
    * @param loader - Optional progress indicator
    * @returns Remote artifact info if upload successful, throws otherwise
    */
   upload({
-    artifact,
+    artifactName,
     loader,
   }: {
-    artifact: LocalArtifact;
+    artifactName: string;
     loader?: ReturnType<typeof spinner>;
   }): Promise<RemoteArtifact>;
 }

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -113,20 +113,8 @@ export function getLocalArtifactPath(artifactName: string) {
 }
 
 export function getLocalBinaryPath(artifactPath: string) {
-  let binaryPath: string | null = null;
   const files = fs.readdirSync(artifactPath);
-
-  // assume there is only one binary in the artifact
-  for (const file of files) {
-    // skip hidden files such as .DS_Store
-    if (file.startsWith('.')) {
-      continue;
-    }
-    if (file) {
-      binaryPath = path.join(artifactPath, file);
-      break;
-    }
-  }
-
-  return binaryPath;
+  // Get the first non-hidden file as the binary
+  const binaryName = files.find((file) => file && !file.startsWith('.'));
+  return binaryName ? path.join(artifactPath, binaryName) : null;
 }

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -4,6 +4,7 @@ import logger from '../logger.js';
 import { getProjectRoot } from '../project.js';
 import { spinner } from '../prompts.js';
 import {
+  getLocalArtifactPath,
   getLocalBinaryPath,
   type RemoteBuildCache,
   type SupportedRemoteCacheProviders,
@@ -69,12 +70,14 @@ Proceeding with local build.`);
   }
 
   loader.start(`Downloading cached build from ${remoteBuildCache.name}`);
+  const localArtifactPath = getLocalArtifactPath(artifactName);
   const fetchedBuild = await remoteBuildCache.download({
     artifact: artifacts[0],
+    targetURL: new URL(localArtifactPath, import.meta.url),
     loader,
   });
 
-  const binaryPath = getLocalBinaryPath(fetchedBuild.path);
+  const binaryPath = getLocalBinaryPath(localArtifactPath);
   if (!binaryPath) {
     loader.stop(`No binary found for "${artifactName}".`);
     return null;
@@ -86,7 +89,7 @@ Proceeding with local build.`);
 
   return {
     name: fetchedBuild.name,
-    artifactPath: fetchedBuild.path,
+    artifactPath: localArtifactPath,
     binaryPath,
   };
 }

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -62,7 +62,7 @@ Proceeding with local build.`);
   loader.stop(`No local build cached. Checking ${remoteBuildCache.name}.`);
 
   const artifacts = await remoteBuildCache.list({ artifactName, limit: 1 });
-  if (!artifacts || artifacts.length === 0) {
+  if (artifacts.length === 0) {
     loader.start('');
     loader.stop(`No cached build found for "${artifactName}".`);
     return null;

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -61,8 +61,8 @@ Proceeding with local build.`);
 
   loader.stop(`No local build cached. Checking ${remoteBuildCache.name}.`);
 
-  const remoteBuild = await remoteBuildCache.query({ artifactName });
-  if (!remoteBuild) {
+  const artifacts = await remoteBuildCache.list({ artifactName, limit: 1 });
+  if (!artifacts || artifacts.length === 0) {
     loader.start('');
     loader.stop(`No cached build found for "${artifactName}".`);
     return null;
@@ -70,7 +70,7 @@ Proceeding with local build.`);
 
   loader.start(`Downloading cached build from ${remoteBuildCache.name}`);
   const fetchedBuild = await remoteBuildCache.download({
-    artifact: remoteBuild,
+    artifact: artifacts[0],
     loader,
   });
 

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -25,7 +25,7 @@ type FetchCachedBuildOptions = {
     | SupportedRemoteCacheProviders
     | undefined
     | null
-    | { new (): RemoteBuildCache };
+    | { (): RemoteBuildCache };
 };
 
 export async function fetchCachedBuild({
@@ -66,9 +66,9 @@ Proceeding with local build.`);
 
   loader.stop(`No local build cached. Checking ${remoteBuildCache.name}.`);
 
-  loader.start(`Downloading cached build from ${remoteBuildCache.name}`);
   const localArtifactPath = getLocalArtifactPath(artifactName);
   const response = await remoteBuildCache.download({ artifactName });
+  loader.start(`Downloading cached build from ${remoteBuildCache.name}`);
   await handleDownloadResponse(
     response,
     localArtifactPath,
@@ -81,7 +81,6 @@ Proceeding with local build.`);
     loader.stop(`No binary found for "${artifactName}".`);
     return null;
   }
-
   loader.stop(
     `Downloaded cached build: ${color.cyan(path.relative(root, binaryPath))}.`
   );

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -52,14 +52,14 @@ Include "repo", "workflow", and "read:org" permissions.`
   }: {
     artifactName?: string;
     limit?: number;
-  }): Promise<RemoteArtifact[] | null> {
+  }): Promise<RemoteArtifact[]> {
     const repoDetails = await this.detectRepoDetails();
     if (!getGitHubToken()) {
       logger.warn(`No GitHub Personal Access Token found.`);
-      return null;
+      return [];
     }
     if (!repoDetails) {
-      return null;
+      return [];
     }
     const artifacts = await fetchGitHubArtifactsByName(
       artifactName,
@@ -67,7 +67,7 @@ Include "repo", "workflow", and "read:org" permissions.`
       limit
     );
     if (artifacts.length === 0) {
-      return null;
+      return [];
     }
     return artifacts.map((artifact) => ({
       name: artifact.name,

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -12,6 +12,7 @@ import type {
 } from '../common.js';
 import { getLocalArtifactPath } from '../common.js';
 import {
+  deleteGitHubArtifacts,
   downloadGitHubArtifact,
   fetchGitHubArtifactsByName,
 } from './artifacts.js';
@@ -57,11 +58,9 @@ Include "repo", "workflow", and "read:org" permissions.`
       logger.warn(`No GitHub Personal Access Token found.`);
       return null;
     }
-
     if (!repoDetails) {
       return null;
     }
-
     const artifacts = await fetchGitHubArtifactsByName(
       artifactName,
       repoDetails,
@@ -70,7 +69,6 @@ Include "repo", "workflow", and "read:org" permissions.`
     if (artifacts.length === 0) {
       return null;
     }
-
     return artifacts.map((artifact) => ({
       name: artifact.name,
       url: artifact.downloadUrl,
@@ -95,10 +93,10 @@ Include "repo", "workflow", and "read:org" permissions.`
   }
 
   async delete({
-    artifactName,
+    artifact,
     loader,
   }: {
-    artifactName: string;
+    artifact: RemoteArtifact;
     loader?: ReturnType<typeof spinner>;
   }): Promise<boolean> {
     const repoDetails = await this.detectRepoDetails();
@@ -106,70 +104,10 @@ Include "repo", "workflow", and "read:org" permissions.`
       logger.warn(`No GitHub Personal Access Token found.`);
       return false;
     }
-
     if (!repoDetails) {
       return false;
     }
-
-    const artifacts = await fetchGitHubArtifactsByName(
-      artifactName,
-      repoDetails
-    );
-
-    if (artifacts.length === 0) {
-      loader?.stop(`No artifact found with name "${artifactName}" to delete.`);
-      return false;
-    }
-
-    loader?.start(
-      `Found ${artifacts.length} artifacts named "${artifactName}". Deleting...`
-    );
-
-    try {
-      const owner = repoDetails.owner;
-      const repo = repoDetails.repository;
-
-      // Delete all matching artifacts
-      let deletedCount = 0;
-      for (const artifact of artifacts) {
-        const artifactId = artifact.id;
-        const url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${artifactId}`;
-
-        const response = await fetch(url, {
-          method: 'DELETE',
-          headers: {
-            Authorization: `Bearer ${getGitHubToken()}`,
-            Accept: 'application/vnd.github+json',
-          },
-        });
-
-        if (!response.ok) {
-          logger.warn(
-            `Failed to delete artifact ID ${artifactId}: ${response.status} ${response.statusText}`
-          );
-          continue;
-        }
-
-        deletedCount++;
-      }
-
-      if (deletedCount < artifacts.length) {
-        loader?.stop(
-          `Partially succeeded: deleted ${deletedCount}/${artifacts.length} artifacts named "${artifactName}".`
-        );
-        return true;
-      } else {
-        loader?.stop(
-          `Successfully deleted all ${deletedCount} artifacts named "${artifactName}".`
-        );
-        return true;
-      }
-    } catch (error) {
-      loader?.stop(
-        `Failed to delete artifacts named "${artifactName}": ${error}`
-      );
-      return false;
-    }
+    return await deleteGitHubArtifacts(artifact, repoDetails, loader);
   }
 
   async upload() {

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -110,9 +110,8 @@ Include "repo", "workflow", and "read:org" permissions.`
     return await deleteGitHubArtifacts(artifact, repoDetails, loader);
   }
 
-  async upload() {
-    logger.warn('Uploading artifacts to GitHub is not supported.');
-    return null;
+  async upload(): Promise<RemoteArtifact> {
+    throw new Error('Uploading artifacts to GitHub is not supported.');
   }
 }
 

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -10,7 +10,6 @@ import type {
   RemoteArtifact,
   RemoteBuildCache,
 } from '../common.js';
-import { getLocalArtifactPath } from '../common.js';
 import {
   deleteGitHubArtifacts,
   downloadGitHubArtifact,
@@ -78,17 +77,22 @@ Include "repo", "workflow", and "read:org" permissions.`
 
   async download({
     artifact,
+    targetURL,
     loader,
   }: {
     artifact: RemoteArtifact;
+    targetURL: URL;
     loader?: ReturnType<typeof spinner>;
   }): Promise<LocalArtifact> {
-    const artifactPath = getLocalArtifactPath(artifact.name);
-    await downloadGitHubArtifact(artifact.url, artifactPath, this.name, loader);
-    await extractArtifactTarballIfNeeded(artifactPath);
+    await downloadGitHubArtifact(
+      artifact.url,
+      targetURL.pathname,
+      this.name,
+      loader
+    );
+    await extractArtifactTarballIfNeeded(targetURL.pathname);
     return {
       name: artifact.name,
-      path: artifactPath,
     };
   }
 

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -83,7 +83,7 @@ export class GitHubBuildCache implements RemoteBuildCache {
   }
 
   async upload(): Promise<RemoteArtifact> {
-    throw new RnefError('Uploading artifacts to GitHub is not supported.');
+    throw new RnefError('Uploading artifacts to GitHub is not supported through GitHub API. See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28');
   }
 }
 

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -1,4 +1,4 @@
-import { RnefError } from '../../error.js';
+
 import type { RemoteArtifact, RemoteBuildCache } from '../common.js';
 import {
   deleteGitHubArtifacts,
@@ -55,7 +55,7 @@ export class GitHubBuildCache implements RemoteBuildCache {
     const repoDetails = await this.getRepoDetails();
     const artifacts = await this.list({ artifactName });
     if (artifacts.length === 0) {
-      throw new RnefError(`No artifact found with name "${artifactName}"`);
+      throw new Error(`No artifact found with name "${artifactName}"`);
     }
     return fetch(artifacts[0].url, {
       headers: {
@@ -77,13 +77,13 @@ export class GitHubBuildCache implements RemoteBuildCache {
       undefined
     );
     if (artifacts.length === 0) {
-      throw new RnefError(`No artifact found with name "${artifactName}"`);
+      throw new Error(`No artifact found with name "${artifactName}"`);
     }
     return await deleteGitHubArtifacts(artifacts, repoDetails, artifactName);
   }
 
   async upload(): Promise<RemoteArtifact> {
-    throw new RnefError('Uploading artifacts to GitHub is not supported through GitHub API. See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28');
+    throw new Error('Uploading artifacts to GitHub is not supported through GitHub API. See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28');
   }
 }
 

--- a/packages/tools/src/lib/build-cache/remoteBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/remoteBuildCache.ts
@@ -1,15 +1,18 @@
 import type { RemoteBuildCache } from './common.js';
 
 export async function createRemoteBuildCache(
-  remoteCacheProvider: 'github-actions' | null | { new (): RemoteBuildCache }
+  remoteCacheProvider: 'github-actions' | null | (() => RemoteBuildCache)
 ): Promise<RemoteBuildCache | null> {
   if (remoteCacheProvider === 'github-actions') {
-    const { GitHubBuildCache } = await import('./github/GitHubBuildCache.js');
-    return new GitHubBuildCache();
+    const { pluginGitHubBuildCache } = await import(
+      './github/GitHubBuildCache.js'
+    );
+    const gitHubCacheProvider = pluginGitHubBuildCache();
+    return gitHubCacheProvider();
   }
 
   if (remoteCacheProvider && typeof remoteCacheProvider !== 'string') {
-    return new remoteCacheProvider();
+    return remoteCacheProvider();
   }
 
   return null;

--- a/packages/tools/src/lib/fingerprint/index.ts
+++ b/packages/tools/src/lib/fingerprint/index.ts
@@ -22,7 +22,7 @@ export type FingerprintResult = {
 };
 
 /**
- * Calculates the fingerprint of the native parts project o the project.
+ * Calculates the fingerprint of the native parts project of the project.
  */
 export async function nativeFingerprint(
   path: string,

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -140,13 +140,17 @@ export default {
 
 ## Remote Cache Configuration
 
-One of the key features of RNEF is remote build caching to speed up your development workflow. When set, the CLI will:
+One of the key features of RNEF is remote build caching to speed up your development workflow. By remote cache we mean native build artifacts (e.g. APK, or IPA binaries), which are discoverable by the user and available for download. Remote cache can live on any static storage provider, such as S3, R2, or GitHub Artifacts. For RNEF to know how and where to access this cache, you'll need to define `remoteCacheProvider`, which can be either bundled with the framework (such as the one for GitHub Actions) or a custom one that you can provide.
+
+When `remoteCacheProvider` is set, the CLI will:
 
 1. Look at local cache under `.rnef/` directory for builds downloaded from a remote cache.
 1. If not found, it will look for a remote build matching your local native project state (a fingerprint).
 1. If not found, it will fall back to local build.
 
-Currently it's only available as a GitHub Action, for which you can configure it as:
+### Built-in GitHub Actions provider
+
+RNEF comes with built-in GitHub Actions remote cache provider, which downloads native build artifacts uploaded through [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action from [GitHub Worfklow Artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow). You can configure it as:
 
 ```ts
 export default {
@@ -154,6 +158,43 @@ export default {
   remoteCacheProvider: 'github-actions',
 };
 ```
+
+### Custom remote cache provider
+
+You can plug in any remote storage by implementing [`RemoteBuildCache`](https://github.com/callstack/rnef/blob/main/packages/tools/src/lib/build-cache/common.ts#L22) interface. A simplest remote cache provider, that loads artifact from a local directory available on your filesystem, would look like this:
+
+```ts
+class DummyRemoteCacheProvider {
+  name = 'dummy';
+  // artifactName is provided by RNEF, and will look like rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4
+  async list({ artifactName, limit }) {
+    const url = `/path/to/${artifactName}`;
+    return [{ name: artifactName, url }];
+  }
+  async download({ artifact, loader }) {
+    return { name: artifact.name, path: artifact.url };
+  }
+  async delete({ artifactName, loader }) {
+    return false;
+  }
+  async upload({ artifactPath, artifactName, loader }) {
+    return null;
+  }
+}
+```
+
+Then pass this class as a value of the `remoteCacheProvider` config key:
+
+```ts
+export default {
+  // ...
+  remoteCacheProvider: DummyRemoteCacheProvider,
+};
+```
+
+Once this is set up, when running `run:[platform]` commands, RNEF will calculate the hash of your native project for said platform, and use your `download` method to resolve the path to the binary that will be installed on a device.
+
+### Opt-out of remote cache
 
 If you only want to use the CLI without the remote cache, and skip the steps `1.` and `2.` and a warning that you're not using a remote provider, you can disable this functionality by setting it to `null`:
 
@@ -181,3 +222,7 @@ export default {
 ```
 
 The fingerprint calculation uses [`@expo/fingerprint`](https://docs.expo.dev/versions/latest/sdk/fingerprint/) under the hood.
+
+```
+
+```

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -164,7 +164,7 @@ export default {
 You can plug in any remote storage by implementing [`RemoteBuildCache`](https://github.com/callstack/rnef/blob/main/packages/tools/src/lib/build-cache/common.ts#L24) interface. A simplest remote cache provider, that loads artifact from a local directory available on your filesystem, would look like this:
 
 ```ts
-class DummyLocalCacheProvider {
+class DummyLocalCacheProvider implements RemoteBuildCache {
   name = 'dummy';
   // artifactName is provided by RNEF, and will look like this:
   // - rnef-android-release-7af554b93cd696ca95308fdebe3a4484001bb7b4
@@ -179,6 +179,12 @@ class DummyLocalCacheProvider {
     const filePath = artifacts[0].url.pathname;
     const fileStream = fs.createReadStream(filePath);
     return new Response(fileStream);
+  }
+  async delete({ artifactName }: { artifactName: string }) {
+    // ...
+  }
+  async upload({ artifactName }: { artifactName: string }) {
+    // ...
   }
 }
 

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -164,6 +164,8 @@ export default {
 You can plug in any remote storage by implementing [`RemoteBuildCache`](https://github.com/callstack/rnef/blob/main/packages/tools/src/lib/build-cache/common.ts#L24) interface. A simplest remote cache provider, that loads artifact from a local directory available on your filesystem, would look like this:
 
 ```ts
+import type { RemoteBuildCache } from '@rnef/tools'; // dev dependency of provider
+
 class DummyLocalCacheProvider implements RemoteBuildCache {
   name = 'dummy';
   // artifactName is provided by RNEF, and will look like this:

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -161,20 +161,19 @@ export default {
 
 ### Custom remote cache provider
 
-You can plug in any remote storage by implementing [`RemoteBuildCache`](https://github.com/callstack/rnef/blob/main/packages/tools/src/lib/build-cache/common.ts#L22) interface. A simplest remote cache provider, that loads artifact from a local directory available on your filesystem, would look like this:
+You can plug in any remote storage by implementing [`RemoteBuildCache`](https://github.com/callstack/rnef/blob/main/packages/tools/src/lib/build-cache/common.ts#L27) interface. A simplest remote cache provider, that loads artifact from a local directory available on your filesystem, would look like this:
 
 ```ts
 class DummyRemoteCacheProvider {
   name = 'dummy';
   // artifactName is provided by RNEF, and will look like rnef-android-debug-7af554b93cd696ca95308fdebe3a4484001bb7b4
   async list({ artifactName, limit }) {
-    const url = `/path/to/${artifactName}`;
-    return [{ name: artifactName, url }];
+    return [{ name: artifactName, url: `/path/to/${artifactName}` }];
   }
   async download({ artifact, loader }) {
     return { name: artifact.name, path: artifact.url };
   }
-  async delete({ artifactName, loader }) {
+  async delete({ artifact, loader }) {
     return false;
   }
   async upload({ artifactPath, artifactName, loader }) {

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -231,7 +231,3 @@ export default {
 ```
 
 The fingerprint calculation uses [`@expo/fingerprint`](https://docs.expo.dev/versions/latest/sdk/fingerprint/) under the hood.
-
-```
-
-```

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -173,12 +173,7 @@ class DummyRemoteCacheProvider {
   async download({ artifact, loader }) {
     return { name: artifact.name, path: artifact.url };
   }
-  async delete({ artifact, loader }) {
-    return false;
-  }
-  async upload({ artifactPath, artifactName, loader }) {
-    return null;
-  }
+  // optionally implement delete and upload methods
 }
 ```
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This diff adds support for writing your own custom remote providers, which was quasi-supported previously.

Notable changes: 
- Changed the remote cache interface to:
  ```ts
  /**
   * Interface for implementing remote build cache providers.
   * Remote cache providers allow storing and retrieving native build artifacts (e.g. APK, IPA)
   * from remote storage like S3, GitHub Artifacts etc.
   */
  export interface RemoteBuildCache {
    /** Unique identifier for this cache provider, will be displayed in logs */
    name: string;
  
    /**
     * List available artifacts matching the given name pattern
     * @param artifactName - Passed after fingerprinting the build, e.g. `rnef-android-debug-1234567890` for android in debug variant
     * @param limit - Optional maximum number of artifacts to return
     * @returns Array of matching remote artifacts, or empty array if none found
     */
    list({
      artifactName,
      limit,
    }: {
      artifactName: string | undefined;
      limit?: number;
    }): Promise<RemoteArtifact[]>;
  
    /**
     * Download a remote artifact to local storage
     * @param artifactName - Name of the artifact to download, e.g. `rnef-android-debug-1234567890` for android in debug variant
     * @returns Response object from fetch, which will be used to download the artifact
     */
    download({ artifactName }: { artifactName: string }): Promise<Response>;
  
    /**
     * Delete a remote artifact
     * @param artifact - Remote artifact to delete, as returned by `list` method
     * Throws if artifact is not found or deletion fails
     */
    delete({ artifactName }: { artifactName: string }): Promise<RemoteArtifact[]>;
  
    /**
     * Upload a local artifact stored in build cache to remote storage
     * @param artifactName - Name of the artifact to upload, e.g. `rnef-android-debug-1234567890` for android in debug variant
     * @returns Remote artifact info if upload successful, throws otherwise
     */
    upload({ artifactName }: { artifactName: string }): Promise<RemoteArtifact>;
  }
  ```
- made `remoteCacheProvider` to accept a function that returns a class that implements `RemoteBuildCache`, so that we can configure input parameters, such as auth data, or repo information
  ```ts
  // rnef.config.mjs
  export default {
    // ...
    remoteCacheProvider: pluginGitHubBuildCache({
      owner: 'callstack-internal',
      repository: 'rnef-remote-build-test',
      token: '<token>',
    }),
  }
  ```
- Added docs with a dummy remote cache that works (previously it would fail with wrong schema type).
- Implemented `delete` method for GitHub provider that deletes all matching artifacts (there can be many with the same name)
- changed `query` to `list` that returns a list of artifacts

### Test plan

Added unit test for creating and using remote cache provider.