### PR TITLE
fix: remote-cache list returninig undefined instead of empty

### DIFF
--- a/.changeset/fifty-items-shop.md
+++ b/.changeset/fifty-items-shop.md
@@ -1,0 +1,5 @@
+---
+'@rnef/cli': patch
+---
+
+fix: remote-cache list returninig undefined instead of empty

--- a/packages/cli/src/lib/plugins/remoteCache.ts
+++ b/packages/cli/src/lib/plugins/remoteCache.ts
@@ -57,15 +57,14 @@ async function remoteCache({
   switch (action) {
     case 'list': {
       const artifacts = await remoteBuildCache.list({ artifactName });
-      if (artifacts) {
+      const artifact = artifacts[0];
+      if (artifact) {
         if (isJsonOutput) {
-          console.log(JSON.stringify(artifacts[0], null, 2));
+          console.log(JSON.stringify(artifact, null, 2));
         } else {
-          logger.log(`- name: ${artifacts[0].name}
-- url: ${artifacts[0].url}`);
+          logger.log(`- name: ${artifact.name}
+  - url: ${artifact.url}`);
         }
-      } else {
-        throw new RnefError(`No artifacts found for "${artifactName}".`);
       }
       break;
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This command should return nothing instead of `undefined` when no artifact matches.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
