### PR TITLE
fix: download message in remote-cache --json

### DIFF
--- a/.changeset/unlucky-lobsters-hunt.md
+++ b/.changeset/unlucky-lobsters-hunt.md
@@ -1,0 +1,6 @@
+---
+'@rnef/tools': patch
+'@rnef/cli': patch
+---
+
+fix: download message in remote-cache --json

--- a/packages/cli/src/lib/plugins/remoteCache.ts
+++ b/packages/cli/src/lib/plugins/remoteCache.ts
@@ -11,7 +11,6 @@ import {
   handleDownloadResponse,
   logger,
   RnefError,
-  spinner,
 } from '@rnef/tools';
 
 type Flags = {
@@ -92,13 +91,7 @@ async function remoteCache({
     case 'download': {
       const localArtifactPath = getLocalArtifactPath(artifactName);
       const response = await remoteBuildCache.download({ artifactName });
-      const loader = spinner();
-      await handleDownloadResponse(
-        response,
-        localArtifactPath,
-        artifactName,
-        loader
-      );
+      await handleDownloadResponse(response, localArtifactPath, artifactName);
       const binaryPath = getLocalBinaryPath(localArtifactPath);
       if (!binaryPath) {
         throw new RnefError(`No binary found for "${artifactName}".`);

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -96,7 +96,7 @@ export async function handleDownloadResponse(
   response: Response,
   localArtifactPath: string,
   name: string,
-  loader: ReturnType<typeof spinner>
+  loader?: ReturnType<typeof spinner>
 ) {
   try {
     fs.mkdirSync(localArtifactPath, { recursive: true });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Turn off download progress from `remote-cache download` command for now

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
