### PR TITLE
feat: add --all flag to list and delete, --all-but-latest to delete;

### DIFF
--- a/.changeset/bright-rabbits-bathe.md
+++ b/.changeset/bright-rabbits-bathe.md
@@ -1,0 +1,6 @@
+---
+'@rnef/tools': patch
+'@rnef/cli': patch
+---
+
+feat: add --all flag to list and delete, --all-but-latest to delete

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -49,11 +49,21 @@ export interface RemoteBuildCache {
 
   /**
    * Delete a remote artifact
-   * @param artifact - Remote artifact to delete, as returned by `list` method
+   * @param artifactName - Name of the artifact to delete, e.g. `rnef-android-debug-1234567890` for android in debug variant
+   * @param limit - Optional maximum number of artifacts to delete
+   * @param skipLatest - Optional flag to skip the latest artifact, helpful when deleting all but the latest artifact
    * @returns Array of deleted artifacts
    * @throws {Error} Throws if artifact is not found or deletion fails
    */
-  delete({ artifactName }: { artifactName: string }): Promise<RemoteArtifact[]>;
+  delete({
+    artifactName,
+    limit,
+    skipLatest,
+  }: {
+    artifactName: string;
+    limit?: number;
+    skipLatest?: boolean;
+  }): Promise<RemoteArtifact[]>;
 
   /**
    * Upload a local artifact stored in build cache to remote storage

--- a/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
+++ b/packages/tools/src/lib/build-cache/github/GitHubBuildCache.ts
@@ -67,19 +67,28 @@ export class GitHubBuildCache implements RemoteBuildCache {
 
   async delete({
     artifactName,
+    limit,
+    skipLatest,
   }: {
     artifactName: string;
+    limit?: number;
+    skipLatest?: boolean;
   }): Promise<RemoteArtifact[]> {
     const repoDetails = await this.getRepoDetails();
     const artifacts = await fetchGitHubArtifactsByName(
       artifactName,
       repoDetails,
-      undefined
+      limit
     );
     if (artifacts.length === 0) {
       throw new Error(`No artifact found with name "${artifactName}"`);
     }
-    return await deleteGitHubArtifacts(artifacts, repoDetails, artifactName);
+    const [, ...rest] = artifacts;
+    return await deleteGitHubArtifacts(
+      skipLatest ? rest : artifacts,
+      repoDetails,
+      artifactName
+    );
   }
 
   async upload(): Promise<RemoteArtifact> {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add new flags to `remote-cache` command:
- `--all`: applies to `list` and `delete` actions, instructing to list/delete all matching artifacts
- `--all-but-latest`: applies to `delete`, instructing it to delete all artifacts except the latest one (first one listed)
- the `delete` action by default will only remove one latest item now

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
