### PR TITLE
feat: unify --destination and --destinations flags Apple platforms

### DIFF
--- a/.changeset/lucky-jobs-taste.md
+++ b/.changeset/lucky-jobs-taste.md
@@ -1,0 +1,7 @@
+---
+'@rnef/platform-apple-helpers': minor
+'@rnef/plugin-brownfield-ios': minor
+'rnef-docs': patch
+---
+
+unify --destination and --destinations flags; fix building universal (device+simu) iOS brownfield framework

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -76,12 +76,13 @@ export const cli = async ({ cwd, argv }: CliOptions) => {
 
     // Flags
     for (const opt of command.options || []) {
-      cmd.option(
-        opt.name,
-        opt.description,
-        opt.parse ?? ((val) => val),
-        opt.default
-      );
+      // Note: we cannot use default idempotent parse, as it prevents us from using variadic options.
+      if (opt.parse) {
+        cmd.option(opt.name, opt.description, opt.parse, opt.default);
+      } else {
+        // @ts-expect-error - TS types for our default do not match commander types
+        cmd.option(opt.name, opt.description, opt.default);
+      }
     }
   });
 

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -80,7 +80,6 @@ export const cli = async ({ cwd, argv }: CliOptions) => {
       if (opt.parse) {
         cmd.option(opt.name, opt.description, opt.parse, opt.default);
       } else {
-        // @ts-expect-error - TS types for our default do not match commander types
         cmd.option(opt.name, opt.description, opt.default);
       }
     }

--- a/packages/config/src/lib/config.ts
+++ b/packages/config/src/lib/config.ts
@@ -35,7 +35,7 @@ type PluginType = (args: PluginApi) => PluginOutput;
 
 type PlatformType = (args: PluginApi) => PlatformOutput;
 
-type ArgValue = string | string[] | number | boolean;
+type ArgValue = string | string[] | boolean;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ActionType<T = any> = (...args: T[]) => void | Promise<void>;

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
@@ -11,8 +11,6 @@ export type BuildFlags = {
   exportExtraParams?: string[];
   exportOptionsPlist?: string;
   buildFolder?: string;
-  /** @deprecated Use destinations instead */
-  destinationXxx?: 'device' | 'simulator';
   destinations?: string[];
   archive?: boolean;
   installPods: boolean;

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
@@ -11,7 +11,8 @@ export type BuildFlags = {
   exportExtraParams?: string[];
   exportOptionsPlist?: string;
   buildFolder?: string;
-  destination?: 'device' | 'simulator';
+  /** @deprecated Use destinations instead */
+  destinationXxx?: 'device' | 'simulator';
   destinations?: string[];
   archive?: boolean;
   installPods: boolean;
@@ -54,7 +55,8 @@ export const getBuildOptions = ({ platformName }: BuilderCommand) => {
     },
     {
       name: '--export-options-plist <string>',
-      description: 'Name of the export options file for archiving. Defaults to: ExportOptions.plist',
+      description:
+        'Name of the export options file for archiving. Defaults to: ExportOptions.plist',
     },
     {
       name: '--build-folder <string>',

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
@@ -11,7 +11,7 @@ export type BuildFlags = {
   exportExtraParams?: string[];
   exportOptionsPlist?: string;
   buildFolder?: string;
-  destinations?: string[];
+  destination?: string[];
   archive?: boolean;
   installPods: boolean;
   newArch: boolean;
@@ -62,15 +62,9 @@ export const getBuildOptions = ({ platformName }: BuilderCommand) => {
       value: 'build',
     },
     {
-      name: '--destination <string>',
+      name: '--destination <strings...>',
       description:
-        'Define whether to build for a generic device or generic simulator. Available values: "simulator", "device"',
-    },
-    {
-      name: '--destinations <list>',
-      description:
-        'Explicitly defined destinations e.g. "arch=x86_64". You can also pass a comma separated array e.g. "generic/platform=iphoneos,generic/platform=iphonesimulator"',
-      parse: (val: string) => val.split(','),
+        'Define destination(s) for the build. You can pass multiple destinations as separate values or repeated use of the flag. Values can be either: "simulator", "device" or destinations supported by "xcodebuild -destination" flag, e.g. "generic/platform=iOS"',
     },
     {
       name: '--archive',

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -2,12 +2,11 @@ import path from 'node:path';
 import type { SubprocessError } from '@rnef/tools';
 import { color, logger, RnefError, spawn, spinner } from '@rnef/tools';
 import type { ApplePlatform, XcodeProjectInfo } from '../../types/index.js';
+import { getGenericDestination } from '../../utils/destionation.js';
 import { getBuildPaths } from '../../utils/getBuildPaths.js';
 import { supportedPlatforms } from '../../utils/supportedPlatforms.js';
 import type { RunFlags } from '../run/runOptions.js';
 import type { BuildFlags } from './buildOptions.js';
-import { simulatorDestinationMap } from './simulatorDestinationMap.js';
-import { getGenericDestination } from '../../utils/destionation.js';
 
 let lastProgress = 0;
 /**

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -7,6 +7,7 @@ import { supportedPlatforms } from '../../utils/supportedPlatforms.js';
 import type { RunFlags } from '../run/runOptions.js';
 import type { BuildFlags } from './buildOptions.js';
 import { simulatorDestinationMap } from './simulatorDestinationMap.js';
+import { getGenericDestination } from '../../utils/destionation.js';
 
 let lastProgress = 0;
 /**
@@ -84,9 +85,7 @@ export const buildProject = async ({
   args: RunFlags | BuildFlags;
   deviceName?: string;
 }) => {
-  const simulatorDest = simulatorDestinationMap[platformName];
-
-  if (!simulatorDest) {
+  if (!supportedPlatforms[platformName]) {
     throw new RnefError(
       `Unknown platform: ${platformName}. Please, use one of: ${Object.values(
         supportedPlatforms
@@ -100,12 +99,7 @@ export const buildProject = async ({
     }
 
     if (args.destination) {
-      if (args.destination === 'simulator') {
-        return [`generic/platform=${simulatorDest}`];
-      }
-      if (args.destination === 'device') {
-        return [`generic/platform=${platformName}`];
-      }
+      return [getGenericDestination(platformName, args.destination)];
     }
 
     if ('catalyst' in args && args.catalyst) {
@@ -120,7 +114,7 @@ export const buildProject = async ({
       return [`name=${deviceName}`];
     }
 
-    return [`generic/platform=${platformName}`];
+    return [getGenericDestination(platformName, 'device')];
   }
 
   const destinations = determineDestinations().flatMap((destination) => [

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -92,13 +92,14 @@ export const buildProject = async ({
     );
   }
 
+  // At this stage the destinations should already be set
   function determineDestinations(): string[] {
     if (args.destinations) {
       return args.destinations;
     }
 
-    if (args.destination) {
-      return [getGenericDestination(platformName, args.destination)];
+    if (args.destinationXxx) {
+      return [getGenericDestination(platformName, args.destinationXxx)];
     }
 
     if ('catalyst' in args && args.catalyst) {

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -103,4 +103,8 @@ async function validateArgs(args: BuildFlags) {
       process.exit(1);
     }
   }
+
+  if (typeof args.destination === 'string') {
+    args.destination = [args.destination];
+  }
 }

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -8,13 +8,11 @@ import {
   spinner,
 } from '@rnef/tools';
 import type {
-  ApplePlatform,
   BuilderCommand,
   ProjectConfig,
   XcodeProjectInfo,
 } from '../../types/index.js';
 import { buildApp } from '../../utils/buildApp.js';
-import { getGenericDestination } from '../../utils/destionation.js';
 import { getBuildPaths } from '../../utils/getBuildPaths.js';
 import type { BuildFlags } from './buildOptions.js';
 import { exportArchive } from './exportArchive.js';

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -32,16 +32,7 @@ export const createBuild = async ({
   projectRoot: string;
   reactNativePath: string;
 }) => {
-  console.log('CreateBuild(0) destinations', args.destinations);
   await validateArgs(args);
-  console.log('CreateBuild(1) destinations', args.destinations);
-
-  if (args.destinations) {
-    args.destinations = args.destinations.map((destination) =>
-      resolveDestination(destination, platformName)
-    );
-    console.log('CreateBuild(2) destinations', args.destinations);
-  }
 
   let xcodeProject: XcodeProjectInfo;
   let sourceDir: string;
@@ -83,7 +74,7 @@ export const createBuild = async ({
 };
 
 async function validateArgs(args: BuildFlags) {
-  if (!args.destinations) {
+  if (!args.destination) {
     if (isInteractive()) {
       const destination = await promptSelect({
         message: 'Select destination for a generic build',
@@ -99,30 +90,19 @@ async function validateArgs(args: BuildFlags) {
         ],
       });
 
-      args.destinations = [destination];
+      args.destination = [destination];
 
       logger.info(
-        `You can set configuration manually next time using "--destinations ${destination}" flag.`
+        `You can set configuration manually next time using "--destination ${destination}" flag.`
       );
     } else {
       logger.error(
-        `The "--destinations" flag is required in non-interactive environments. Available flag values:
-- simulator – suitable for unsigned simulator builds for developers
-- device – suitable for signed device builds for testers`
+        `The "--destination" flag is required in non-interactive environments. Available flag values:
+- "simulator" – suitable for unsigned simulator builds for developers
+- "device" – suitable for signed device builds for testers
+- or values supported by "xcodebuild -destination" flag, e.g. "generic/platform=iOS"`
       );
       process.exit(1);
     }
   }
-}
-
-function resolveDestination(destination: string, platformName: ApplePlatform) {
-  if (destination === 'device') {
-    return getGenericDestination(platformName, 'device');
-  }
-
-  if (destination === 'simulator') {
-    return getGenericDestination(platformName, 'simulator');
-  }
-
-  return destination;
 }

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -103,8 +103,4 @@ async function validateArgs(args: BuildFlags) {
       process.exit(1);
     }
   }
-
-  if (typeof args.destination === 'string') {
-    args.destination = [args.destination];
-  }
 }

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -17,11 +17,8 @@ import type {
   ProjectConfig,
 } from '../../types/index.js';
 import { buildApp } from '../../utils/buildApp.js';
-import {
-  getDevicePlatformSDK,
-  getPlatformInfo,
-  getSimulatorPlatformSDK,
-} from '../../utils/getPlatformInfo.js';
+import { getGenericDestination } from '../../utils/destionation.js';
+import { getPlatformInfo } from '../../utils/getPlatformInfo.js';
 import { listDevicesAndSimulators } from '../../utils/listDevices.js';
 import { matchingDevice } from './matchingDevice.js';
 import { cacheRecentDevice, sortByRecentDevices } from './recentDevices.js';
@@ -51,7 +48,10 @@ export const createRun = async ({
   if (!args.binaryPath && args.remoteCache) {
     const artifactName = await formatArtifactName({
       platform: 'ios',
-      traits: [args.destination ?? 'simulator', args.configuration ?? 'Debug'],
+      traits: [
+        args.destinationXxx ?? 'simulator',
+        args.configuration ?? 'Debug',
+      ],
       root: projectRoot,
       fingerprintOptions,
     });
@@ -78,10 +78,12 @@ export const createRun = async ({
 
   if (platformName === 'macos') {
     const { appPath } = await buildApp({
-      args,
+      args: {
+        ...args,
+        destinations: [getGenericDestination(platformName, 'simulator')],
+      },
       projectConfig,
       platformName,
-      platformSDK: getSimulatorPlatformSDK(platformName),
       projectRoot,
       udid,
       deviceName,
@@ -91,10 +93,12 @@ export const createRun = async ({
     return;
   } else if (args.catalyst) {
     const { appPath, scheme } = await buildApp({
-      args,
+      args: {
+        ...args,
+        destinations: [getGenericDestination(platformName, 'simulator')],
+      },
       projectConfig,
       platformName,
-      platformSDK: getSimulatorPlatformSDK(platformName),
       projectRoot,
       udid,
       deviceName,
@@ -126,10 +130,12 @@ export const createRun = async ({
       const [, { appPath, infoPlistPath }] = await Promise.all([
         launchSimulator(device),
         buildApp({
-          args,
+          args: {
+            ...args,
+            destinations: [getGenericDestination(platformName, 'simulator')],
+          },
           projectConfig,
           platformName,
-          platformSDK: getSimulatorPlatformSDK(platformName),
           udid: device.udid,
           projectRoot,
           reactNativePath,
@@ -139,10 +145,12 @@ export const createRun = async ({
       await runOnSimulator(device, appPath, infoPlistPath);
     } else if (device.type === 'device') {
       const { appPath } = await buildApp({
-        args,
+        args: {
+          ...args,
+          destinations: [getGenericDestination(platformName, 'device')],
+        },
         projectConfig,
         platformName,
-        platformSDK: getDevicePlatformSDK(platformName),
         udid: device.udid,
         projectRoot,
         reactNativePath,
@@ -180,10 +188,12 @@ export const createRun = async ({
       const [, { appPath, infoPlistPath }] = await Promise.all([
         launchSimulator(simulator),
         buildApp({
-          args,
+          args: {
+            ...args,
+            destinations: [getGenericDestination(platformName, 'simulator')],
+          },
           projectConfig,
           platformName,
-          platformSDK: getSimulatorPlatformSDK(platformName),
           udid: simulator.udid,
           projectRoot,
           reactNativePath,

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -45,6 +45,8 @@ export const createRun = async ({
   fingerprintOptions: { extraSources: string[]; ignorePaths: string[] };
   reactNativePath: string;
 }) => {
+  console.log('createRun(1)', typeof remoteCacheProvider, remoteCacheProvider);
+
   if (!args.binaryPath && args.remoteCache) {
     const artifactName = await formatArtifactName({
       platform: 'ios',

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -45,8 +45,6 @@ export const createRun = async ({
   fingerprintOptions: { extraSources: string[]; ignorePaths: string[] };
   reactNativePath: string;
 }) => {
-  console.log('createRun(1)', typeof remoteCacheProvider, remoteCacheProvider);
-
   if (!args.binaryPath && args.remoteCache) {
     const artifactName = await formatArtifactName({
       platform: 'ios',

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -51,7 +51,7 @@ export const createRun = async ({
     const artifactName = await formatArtifactName({
       platform: 'ios',
       traits: [
-        args.destinationXxx ?? 'simulator',
+        args.destinations?.[0] ?? 'simulator',
         args.configuration ?? 'Debug',
       ],
       root: projectRoot,

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -51,7 +51,7 @@ export const createRun = async ({
     const artifactName = await formatArtifactName({
       platform: 'ios',
       traits: [
-        args.destinations?.[0] ?? 'simulator',
+        args.destination?.[0] ?? 'simulator',
         args.configuration ?? 'Debug',
       ],
       root: projectRoot,
@@ -81,8 +81,8 @@ export const createRun = async ({
   if (platformName === 'macos') {
     const { appPath } = await buildApp({
       args: {
+        destination: [getGenericDestination(platformName, 'simulator')],
         ...args,
-        destinations: [getGenericDestination(platformName, 'simulator')],
       },
       projectConfig,
       platformName,
@@ -96,8 +96,8 @@ export const createRun = async ({
   } else if (args.catalyst) {
     const { appPath, scheme } = await buildApp({
       args: {
+        destination: [getGenericDestination(platformName, 'simulator')],
         ...args,
-        destinations: [getGenericDestination(platformName, 'simulator')],
       },
       projectConfig,
       platformName,
@@ -133,8 +133,8 @@ export const createRun = async ({
         launchSimulator(device),
         buildApp({
           args: {
+            destination: [getGenericDestination(platformName, 'simulator')],
             ...args,
-            destinations: [getGenericDestination(platformName, 'simulator')],
           },
           projectConfig,
           platformName,
@@ -148,8 +148,8 @@ export const createRun = async ({
     } else if (device.type === 'device') {
       const { appPath } = await buildApp({
         args: {
+          destination: [getGenericDestination(platformName, 'device')],
           ...args,
-          destinations: [getGenericDestination(platformName, 'device')],
         },
         projectConfig,
         platformName,
@@ -191,8 +191,8 @@ export const createRun = async ({
         launchSimulator(simulator),
         buildApp({
           args: {
+            destination: [getGenericDestination(platformName, 'simulator')],
             ...args,
-            destinations: [getGenericDestination(platformName, 'simulator')],
           },
           projectConfig,
           platformName,

--- a/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
@@ -12,9 +12,9 @@ type BuildSettings = {
 export async function getBuildSettings(
   xcodeProject: XcodeProjectInfo,
   sourceDir: string,
+  platformName: ApplePlatform,
   configuration: string,
   destinations: string[],
-  platformName: ApplePlatform,
   scheme: string,
   target?: string
 ): Promise<{ appPath: string; infoPlistPath: string }> {

--- a/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { color, logger, RnefError, spawn } from '@rnef/tools';
-import type { XcodeProjectInfo } from '../../types/index.js';
-import type { PlatformSDK } from '../../utils/getPlatformInfo.js';
+import type { ApplePlatform, XcodeProjectInfo } from '../../types/index.js';
 
 type BuildSettings = {
   TARGET_BUILD_DIR: string;
@@ -14,7 +13,8 @@ export async function getBuildSettings(
   xcodeProject: XcodeProjectInfo,
   sourceDir: string,
   configuration: string,
-  platformSDK: PlatformSDK,
+  destinations: string[],
+  platformName: ApplePlatform,
   scheme: string,
   target?: string
 ): Promise<{ appPath: string; infoPlistPath: string }> {
@@ -26,9 +26,9 @@ export async function getBuildSettings(
       '-scheme',
       scheme,
       '-sdk',
-      platformSDK,
       '-configuration',
       configuration,
+      ...destinations.flatMap((destination) => ['-destination', destination]),
       '-showBuildSettings',
       '-json',
     ],
@@ -71,7 +71,7 @@ export async function getBuildSettings(
       throw new RnefError('Failed to get build settings for your project');
     }
 
-    const appPath = getBuildPath(buildSettings, platformSDK);
+    const appPath = getBuildPath(buildSettings, platformName);
     const infoPlistPath = buildSettings.INFOPLIST_PATH;
     const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
 
@@ -86,7 +86,10 @@ export async function getBuildSettings(
   );
 }
 
-function getBuildPath(buildSettings: BuildSettings, platformSDK: PlatformSDK) {
+function getBuildPath(
+  buildSettings: BuildSettings,
+  platformName: ApplePlatform
+) {
   const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
   const executableFolderPath = buildSettings.EXECUTABLE_FOLDER_PATH;
   const fullProductName = buildSettings.FULL_PRODUCT_NAME;
@@ -103,7 +106,7 @@ function getBuildPath(buildSettings: BuildSettings, platformSDK: PlatformSDK) {
     throw new Error('Failed to get product name.');
   }
 
-  if (platformSDK === 'macosx') {
+  if (platformName === 'macos') {
     return path.join(targetBuildDir, fullProductName);
   } else {
     return path.join(targetBuildDir, executableFolderPath);

--- a/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
@@ -25,7 +25,6 @@ export async function getBuildSettings(
       xcodeProject.name,
       '-scheme',
       scheme,
-      '-sdk',
       '-configuration',
       configuration,
       ...destinations.flatMap((destination) => ['-destination', destination]),

--- a/packages/platform-apple-helpers/src/lib/index.ts
+++ b/packages/platform-apple-helpers/src/lib/index.ts
@@ -3,6 +3,7 @@ export { createRun } from './commands/run/createRun.js';
 export { getBuildOptions, BuildFlags } from './commands/build/buildOptions.js';
 export { getRunOptions, RunFlags } from './commands/run/runOptions.js';
 export { modifyIpa, type ModifyIpaOptions } from './commands/sign/modifyIpa.js';
+export { genericDestinations } from './utils/destionation.js';
 export { getBuildPaths } from './utils/getBuildPaths.js';
 export { getInfo } from './utils/getInfo.js';
 export { getScheme } from './utils/getScheme.js';

--- a/packages/platform-apple-helpers/src/lib/types/index.ts
+++ b/packages/platform-apple-helpers/src/lib/types/index.ts
@@ -4,7 +4,6 @@ type ObjectValues<T> = T[keyof T];
 
 export type ApplePlatform = ObjectValues<typeof supportedPlatforms>;
 
-export type Destination = 'simulator' | 'device';
 export interface Device {
   name: string;
   udid: string;

--- a/packages/platform-apple-helpers/src/lib/types/index.ts
+++ b/packages/platform-apple-helpers/src/lib/types/index.ts
@@ -4,6 +4,7 @@ type ObjectValues<T> = T[keyof T];
 
 export type ApplePlatform = ObjectValues<typeof supportedPlatforms>;
 
+export type Destination = 'simulator' | 'device';
 export interface Device {
   name: string;
   udid: string;

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -8,7 +8,6 @@ import type { RunFlags } from '../commands/run/runOptions.js';
 import type { ApplePlatform, ProjectConfig } from '../types/index.js';
 import { getConfiguration } from './getConfiguration.js';
 import { getInfo } from './getInfo.js';
-import type { PlatformSDK } from './getPlatformInfo.js';
 import { getScheme } from './getScheme.js';
 import { getValidProjectConfig } from './getValidProjectConfig.js';
 import { installPodsIfNeeded } from './pods.js';
@@ -18,7 +17,6 @@ export async function buildApp({
   projectConfig,
   pluginConfig,
   platformName,
-  platformSDK,
   udid,
   projectRoot,
   deviceName,
@@ -28,7 +26,6 @@ export async function buildApp({
   projectConfig: ProjectConfig;
   pluginConfig?: IOSProjectConfig;
   platformName: ApplePlatform;
-  platformSDK: PlatformSDK;
   udid?: string;
   deviceName?: string;
   projectRoot: string;
@@ -73,6 +70,7 @@ export async function buildApp({
   if (!info) {
     throw new RnefError('Failed to get Xcode project information');
   }
+
   const scheme = await getScheme(info.schemes, args.scheme, xcodeProject.name);
   const configuration = await getConfiguration(
     info.configurations,
@@ -88,11 +86,17 @@ export async function buildApp({
     args,
     deviceName,
   });
+
+  if (!args.destinations) {
+    throw new RnefError('Destinations be set by now');
+  }
+
   const buildSettings = await getBuildSettings(
     xcodeProject,
     sourceDir,
     configuration,
-    platformSDK,
+    args.destinations,
+    platformName,
     scheme,
     args.target
   );

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -125,8 +125,10 @@ function determineDestinations({
   udid,
   deviceName,
 }: DetermineDestinationsArgs): string[] {
-  if (args.destinations) {
-    return args.destinations;
+  if (args.destination && args.destination.length > 0) {
+    return args.destination.map((destination) =>
+      resolveDestination(destination, platformName)
+    );
   }
 
   if ('catalyst' in args && args.catalyst) {
@@ -142,4 +144,16 @@ function determineDestinations({
   }
 
   return [getGenericDestination(platformName, 'device')];
+}
+
+function resolveDestination(destination: string, platformName: ApplePlatform) {
+  if (destination === 'device') {
+    return getGenericDestination(platformName, 'device');
+  }
+
+  if (destination === 'simulator') {
+    return getGenericDestination(platformName, 'simulator');
+  }
+
+  return destination;
 }

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -129,10 +129,6 @@ function determineDestinations({
     return args.destinations;
   }
 
-  if (args.destinationXxx) {
-    return [getGenericDestination(platformName, args.destinationXxx)];
-  }
-
   if ('catalyst' in args && args.catalyst) {
     return ['platform=macOS,variant=Mac Catalyst'];
   }

--- a/packages/platform-apple-helpers/src/lib/utils/destionation.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/destionation.ts
@@ -7,7 +7,7 @@ export type DestinationInfo = {
   simulator: string;
 };
 
-export const genericDestinations: Record<ApplePlatform, DestinationInfo> = {
+export const genericDestinations = {
   ios: {
     device: 'generic/platform=iOS',
     simulator: 'generic/platform=iOS Simulator',
@@ -24,11 +24,11 @@ export const genericDestinations: Record<ApplePlatform, DestinationInfo> = {
     device: 'generic/platform=tvOS',
     simulator: 'generic/platform=tvOS Simulator',
   },
-} as const;
+} as const satisfies Record<ApplePlatform, DestinationInfo>;
 
 export function getGenericDestination(
   platform: ApplePlatform,
   type: DestinationType
-) {
+): string {
   return genericDestinations[platform][type];
 }

--- a/packages/platform-apple-helpers/src/lib/utils/destionation.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/destionation.ts
@@ -1,6 +1,4 @@
-import type { ApplePlatform } from '../types/index.js';
-
-export type DestinationType = 'device' | 'simulator';
+import type { ApplePlatform, DeviceType } from '../types/index.js';
 
 export type DestinationInfo = {
   device: string;
@@ -28,7 +26,7 @@ export const genericDestinations = {
 
 export function getGenericDestination(
   platform: ApplePlatform,
-  type: DestinationType
+  deviceType: DeviceType
 ): string {
-  return genericDestinations[platform][type];
+  return genericDestinations[platform][deviceType];
 }

--- a/packages/platform-apple-helpers/src/lib/utils/destionation.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/destionation.ts
@@ -1,0 +1,34 @@
+import type { ApplePlatform } from '../types/index.js';
+
+export type DestinationType = 'device' | 'simulator';
+
+export type DestinationInfo = {
+  device: string;
+  simulator: string;
+};
+
+export const genericDestinations: Record<ApplePlatform, DestinationInfo> = {
+  ios: {
+    device: 'generic/platform=iOS',
+    simulator: 'generic/platform=iOS Simulator',
+  },
+  macos: {
+    device: 'generic/platform=macOS',
+    simulator: 'generic/platform=macOS',
+  },
+  visionos: {
+    device: 'generic/platform=visionOS',
+    simulator: 'generic/platform=visionOS Simulator',
+  },
+  tvos: {
+    device: 'generic/platform=tvOS',
+    simulator: 'generic/platform=tvOS Simulator',
+  },
+} as const;
+
+export function getGenericDestination(
+  platform: ApplePlatform,
+  type: DestinationType
+) {
+  return genericDestinations[platform][type];
+}

--- a/packages/platform-apple-helpers/src/lib/utils/getPlatformInfo.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/getPlatformInfo.ts
@@ -29,38 +29,3 @@ export function getPlatformInfo(platform: ApplePlatform): PlatformInfo {
       };
   }
 }
-
-export type PlatformSDK =
-  | 'iphonesimulator'
-  | 'macosx'
-  | 'appletvsimulator'
-  | 'xrsimulator'
-  | 'iphoneos'
-  | 'appletvos'
-  | 'xr';
-
-export function getSimulatorPlatformSDK(platform: ApplePlatform): PlatformSDK {
-  switch (platform) {
-    case 'ios':
-      return 'iphonesimulator';
-    case 'macos':
-      return 'macosx';
-    case 'tvos':
-      return 'appletvsimulator';
-    case 'visionos':
-      return 'xrsimulator';
-  }
-}
-
-export function getDevicePlatformSDK(platform: ApplePlatform): PlatformSDK {
-  switch (platform) {
-    case 'ios':
-      return 'iphoneos';
-    case 'macos':
-      return 'macosx';
-    case 'tvos':
-      return 'appletvos';
-    case 'visionos':
-      return 'xr';
-  }
-}

--- a/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
+++ b/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
@@ -3,6 +3,7 @@ import type { PluginApi, PluginOutput } from '@rnef/config';
 import {
   type BuildFlags,
   createBuild,
+  genericDestinations,
   getBuildOptions,
   getBuildPaths,
   getInfo,
@@ -31,8 +32,8 @@ export const pluginBrownfieldIos =
         const { derivedDataDir } = getBuildPaths('ios');
 
         const destinations = args.destinations ?? [
-          'generic/platform=iphoneos',
-          'generic/platform=iphonesimulator',
+          genericDestinations.ios.device,
+          genericDestinations.ios.simulator,
         ];
 
         const buildFolder = args.buildFolder ?? derivedDataDir;

--- a/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
+++ b/packages/plugin-brownfield-ios/src/lib/pluginBrownfieldIos.ts
@@ -31,7 +31,7 @@ export const pluginBrownfieldIos =
         );
         const { derivedDataDir } = getBuildPaths('ios');
 
-        const destinations = args.destinations ?? [
+        const destination = args.destination ?? [
           genericDestinations.ios.device,
           genericDestinations.ios.simulator,
         ];
@@ -53,7 +53,7 @@ export const pluginBrownfieldIos =
         await createBuild({
           platformName: 'ios',
           projectConfig: iosConfig,
-          args: { ...args, scheme, destinations, buildFolder },
+          args: { ...args, scheme, destination, buildFolder },
           projectRoot,
           reactNativePath: api.getReactNativePath(),
         });

--- a/packages/plugin-metro/src/lib/start/command.ts
+++ b/packages/plugin-metro/src/lib/start/command.ts
@@ -18,7 +18,7 @@ export const registerStartCommand = (api: PluginApi) => {
       intro('Starting Metro dev server');
       const root = api.getProjectRoot();
       const { port, startDevServer } = await findDevServerPort(
-        args.port ?? 8081,
+        args.port ? Number(args.port) : 8081,
         root
       );
 
@@ -44,7 +44,6 @@ export const registerStartCommand = (api: PluginApi) => {
       {
         name: '--port <number>',
         description: 'Port to run the server on',
-        parse: Number,
       },
       {
         name: '--host <string>',
@@ -81,7 +80,6 @@ export const registerStartCommand = (api: PluginApi) => {
           'Specifies the maximum number of workers the worker-pool ' +
           'will spawn for transforming files. This defaults to the number of the ' +
           'cores available on your machine.',
-        parse: (workers: string): number => Number(workers),
       },
       {
         name: '--transformer <string>',

--- a/packages/plugin-metro/src/lib/start/runServer.ts
+++ b/packages/plugin-metro/src/lib/start/runServer.ts
@@ -26,10 +26,10 @@ export type StartCommandArgs = {
   customLogReporterPath?: string;
   host?: string;
   https?: boolean;
-  maxWorkers?: number;
+  maxWorkers?: string;
   key?: string;
   platforms: string[];
-  port?: number;
+  port?: string;
   resetCache?: boolean;
   sourceExts?: string[];
   transformer?: string;
@@ -58,7 +58,7 @@ async function runServer(
     },
     {
       config: args.config,
-      maxWorkers: args.maxWorkers,
+      maxWorkers: Number(args.maxWorkers),
       port: args.port,
       resetCache: args.resetCache,
       watchFolders: args.watchFolders,

--- a/packages/plugin-repack/src/lib/pluginRepack.ts
+++ b/packages/plugin-repack/src/lib/pluginRepack.ts
@@ -43,7 +43,7 @@ export const pluginRepack =
         const root = api.getProjectRoot();
         const platforms = api.getPlatforms();
         const { port, startDevServer } = await findDevServerPort(
-          args.port ?? 8081,
+          args.port ? Number(args.port) : 8081,
           root
         );
 
@@ -58,6 +58,7 @@ export const pluginRepack =
           { ...args, port }
         );
       },
+      // @ts-expect-error fixup types
       options: startCommand.options,
     });
 

--- a/packages/tools/src/lib/dev-server/findDevServerPort.ts
+++ b/packages/tools/src/lib/dev-server/findDevServerPort.ts
@@ -6,7 +6,7 @@ export const findDevServerPort = async (
   initialPort: number,
   root: string
 ): Promise<{
-  port: number;
+  port: string;
   startDevServer: boolean;
 }> => {
   let port = initialPort;
@@ -28,7 +28,7 @@ export const findDevServerPort = async (
   }
 
   return {
-    port,
+    port: String(port),
     startDevServer,
   };
 };

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -126,20 +126,19 @@ The `bundle` command creates an optimized JavaScript bundle for your application
 
 The `build:ios` command builds your iOS app for simulators, devices, or distribution, producing either an APP directory (for simulators) or an IPA file (for devices and distribution).
 
-| Option                            | Description                                                                                |
-| :-------------------------------- | :----------------------------------------------------------------------------------------- |
-| `--configuration <string>`        | Xcode scheme configuration (case sensitive)                                                |
-| `--scheme <string>`               | Xcode scheme to use                                                                        |
-| `--target <string>`               | Xcode target to use                                                                        |
-| `--extra-params <string>`         | Custom xcodebuild parameters                                                               |
-| `--export-extra-params <string>`  | Custom xcodebuild export archive parameters                                                |
-| `--export-options-plist <string>` | Export options file for archiving (default: ExportOptions.plist)                           |
-| `--build-folder <string>`         | Location for iOS build artifacts                                                           |
-| `--destination <string>`          | Build target: "simulator" or "device"                                                      |
-| `--destinations <list>`           | Explicit destinations (e.g., "generic/platform=iphoneos,generic/platform=iphonesimulator") |
-| `--archive`                       | Create Xcode archive (IPA)                                                                 |
-| `--no-install-pods`               | Skip CocoaPods installation                                                                |
-| `--no-new-arch`                   | Build in legacy async architecture                                                         |
+| Option                            | Description                                                                                                                                                                                                                                                  |
+| :-------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--configuration <string>`        | Xcode scheme configuration (case sensitive)                                                                                                                                                                                                                  |
+| `--scheme <string>`               | Xcode scheme to use                                                                                                                                                                                                                                          |
+| `--target <string>`               | Xcode target to use                                                                                                                                                                                                                                          |
+| `--extra-params <string>`         | Custom xcodebuild parameters                                                                                                                                                                                                                                 |
+| `--export-extra-params <string>`  | Custom xcodebuild export archive parameters                                                                                                                                                                                                                  |
+| `--export-options-plist <string>` | Export options file for archiving (default: ExportOptions.plist)                                                                                                                                                                                             |
+| `--build-folder <string>`         | Location for iOS build artifacts                                                                                                                                                                                                                             |
+| `--destination <strings...>`      | Define destination(s) for the build. You can pass multiple destinations as separate values or repeated use of the flag. Values can be either: "simulator", "device" or destinations supported by "xcodebuild -destination" flag, e.g. "generic/platform=iOS" |
+| `--archive`                       | Create Xcode archive (IPA)                                                                                                                                                                                                                                   |
+| `--no-install-pods`               | Skip CocoaPods installation                                                                                                                                                                                                                                  |
+| `--no-new-arch`                   | Build in legacy async architecture                                                                                                                                                                                                                           |
 
 ### `rnef run:ios` Options
 

--- a/website/docs/docs/getting-started/introduction.md
+++ b/website/docs/docs/getting-started/introduction.md
@@ -78,7 +78,6 @@ iOS:
 
 - `--mode` → `--configuration`
 - `--buildFolder` → `--build-folder`
-- `--destination` → `--destinations`
 
 ### Removed Flags
 

--- a/website/docs/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/docs/docs/getting-started/migrating-from-community-cli.mdx
@@ -119,7 +119,6 @@ import { PackageManagerTabs } from 'rspress/theme';
    - `--mode` to `--variant` for Android commands
    - `--mode` to `--configuration` for iOS commands
    - `--buildFolder` to `--build-folder` for iOS commands
-   - `--destination` to `--destinations` for iOS commands
    - `--appId` to `--app-id` for Android commands
    - `--appIdSuffix` to `--app-id-suffix` for Android commands
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Scope:
- unify `--destination` and `--destinations` flags for Apple platforms. Now it's single `--destination` flag that accepts either `simulator|device` or xcodebuild destination values.
- fix building universal (device+simu) iOS brownfield framework

Resolves #320 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
