### PR TITLE
fix: mark @rnef/provider-github as optional dependency

### DIFF
--- a/.changeset/fuzzy-clouds-eat.md
+++ b/.changeset/fuzzy-clouds-eat.md
@@ -1,0 +1,5 @@
+---
+'@rnef/config': patch
+---
+
+fix: mark @rnef/provider-github as optional dependency

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,5 +24,8 @@
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.6"
+  },
+  "optionalDependencies": {
+    "@rnef/provider-github": "^0.7.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,10 @@ importers:
       '@types/babel__code-frame':
         specifier: ^7.0.6
         version: 7.0.6
+    optionalDependencies:
+      '@rnef/provider-github':
+        specifier: ^0.7.11
+        version: link:../provider-github
 
   packages/create-app:
     dependencies:

--- a/scripts/update-template-dependencies.sh
+++ b/scripts/update-template-dependencies.sh
@@ -26,10 +26,30 @@ update_package_json() {
                 from_entries
             )
         else . end |
-        
+
         if has("devDependencies") then
             .devDependencies = (
                 .devDependencies | 
+                to_entries | 
+                map(if .key | startswith("@rnef/") then .value = $version else . end) |
+                from_entries
+            )
+
+        else . end |
+        
+        if has("optionalDependencies") then
+            .optionalDependencies = (
+                .optionalDependencies | 
+                to_entries | 
+                map(if .key | startswith("@rnef/") then .value = $version else . end) |
+                from_entries
+            )
+        
+        else . end |
+        
+        if has("peerDependencies") then
+            .peerDependencies = (
+                .peerDependencies | 
                 to_entries | 
                 map(if .key | startswith("@rnef/") then .value = $version else . end) |
                 from_entries


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a crash when specifying provider as `"github-actions"`
<img width="841" alt="image" src="https://github.com/user-attachments/assets/676b1dca-c610-498b-b715-0854203e8c2d" />


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
