### PR TITLE
chore: throw instead of warn when token is invalid

### DIFF
--- a/.changeset/seven-starfishes-cheat.md
+++ b/.changeset/seven-starfishes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@rnef/provider-github': patch
+---
+
+chore: throw instead of warn when token is invalid

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -88,7 +88,7 @@ Please generate a new one at: ${color.cyan(
           'https://github.com/settings/tokens'
         )} or request from your team.
 Include "repo", "workflow", and "read:org" permissions.
-Then update the token under "${color.bold('remoteCacheProvider')}" key in ${color.cyan(
+Update the token under "${color.bold('remoteCacheProvider')}" key in ${color.cyan(
           'rnef.config.mjs'
         )} config file.`
       );

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -90,7 +90,7 @@ Please generate a new one at: ${color.cyan(
 Include "repo", "workflow", and "read:org" permissions.
 Then update the token under "${color.bold('remoteCacheProvider')}" key in ${color.cyan(
           'rnef.config.mjs'
-        )} config or ${color.cyan('.env')} file`
+        )} config file.`
       );
     }
     throw new RnefError(`Failed to fetch GitHub artifacts`, { cause: error });

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -84,13 +84,13 @@ export async function fetchGitHubArtifactsByName(
       cacheManager.remove('githubToken');
       throw new RnefError(
         `Failed to fetch GitHub artifacts due to invalid or expired GitHub Personal Access Token provided.
-Please generate a new one at: ${color.cyan(
-          'https://github.com/settings/tokens'
-        )} or request from your team.
-Include "repo", "workflow", and "read:org" permissions.
-Update the token under "${color.bold('remoteCacheProvider')}" key in ${color.cyan(
-          'rnef.config.mjs'
-        )} config file.`
+Update the token under "${color.bold(
+          'remoteCacheProvider'
+        )}" key in ${color.cyan('rnef.config.mjs')} config file.
+
+📘 Read more about generating a new token: ${color.cyan(
+          'https://www.rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
+        )}`
       );
     }
     throw new RnefError(`Failed to fetch GitHub artifacts`, { cause: error });

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -81,21 +81,19 @@ export async function fetchGitHubArtifactsByName(
     }
   } catch (error) {
     if ((error as { message: string }).message.includes('401 Unauthorized')) {
-      logger.warn(
+      cacheManager.remove('githubToken');
+      throw new RnefError(
         `Failed to fetch GitHub artifacts due to invalid or expired GitHub Personal Access Token provided.
 Please generate a new one at: ${color.cyan(
           'https://github.com/settings/tokens'
-        )}
+        )} or request from your team.
 Include "repo", "workflow", and "read:org" permissions.
-Next time you run the command, you will be prompted to enter the new token.`
-      );
-      cacheManager.remove('githubToken');
-    } else {
-      logger.warn(
-        'Failed to fetch GitHub artifacts: ',
-        (error as { message: string }).message
+Then update the token under "${color.bold('remoteCacheProvider')}" key in ${color.cyan(
+          'rnef.config.mjs'
+        )} config or ${color.cyan('.env')} file`
       );
     }
+    throw new RnefError(`Failed to fetch GitHub artifacts`, { cause: error });
   }
 
   result.sort((a, b) => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Convert warning to error. This requires user action, so it's better to fail fast. Plus people seem to omit warnings pretty often.

|before|after|
|--|--|
|<img width="833" alt="image" src="https://github.com/user-attachments/assets/1dbf477a-722a-4e3e-87c0-49b732473530" />|<img width="713" alt="image" src="https://github.com/user-attachments/assets/4101c4f3-4d22-41ac-8708-4d5dbf8e24c3" />|

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
