### PR TITLE
fix: run without remote set

### DIFF
--- a/.changeset/three-chefs-greet.md
+++ b/.changeset/three-chefs-greet.md
@@ -1,0 +1,6 @@
+---
+'@rnef/provider-github': patch
+'@rnef/tools': patch
+---
+
+fix: running without git remote set

--- a/packages/provider-github/src/lib/getGitRemote.ts
+++ b/packages/provider-github/src/lib/getGitRemote.ts
@@ -1,4 +1,4 @@
-import { cacheManager, logger, promptSelect, spawn } from '@rnef/tools';
+import { cacheManager, promptSelect, spawn } from '@rnef/tools';
 
 export async function getGitRemote() {
   let gitRemote = cacheManager.get('gitRemote');
@@ -23,8 +23,6 @@ export async function getGitRemote() {
   } else if (remotes.length === 1) {
     gitRemote = remotes[0];
   } else {
-    // @todo add "learn more" link to docs when available
-    logger.warn('No git remote found. Proceeding with local build.');
     return null;
   }
 

--- a/packages/provider-github/src/lib/providerGitHub.ts
+++ b/packages/provider-github/src/lib/providerGitHub.ts
@@ -1,9 +1,14 @@
-import type { RemoteArtifact, RemoteBuildCache } from '@rnef/tools';
+import type {
+  CacheAvailabilityState,
+  RemoteArtifact,
+  RemoteBuildCache,
+} from '@rnef/tools';
 import {
   deleteGitHubArtifacts,
   fetchGitHubArtifactsByName,
 } from './artifacts.js';
 import { detectGitHubRepoDetails, type GitHubRepoDetails } from './config.js';
+import { getGitRemote } from './getGitRemote.js';
 
 export class GitHubBuildCache implements RemoteBuildCache {
   name = 'GitHub';
@@ -17,6 +22,15 @@ export class GitHubBuildCache implements RemoteBuildCache {
         token: config.token,
       };
     }
+  }
+
+  async getAvailabilityState(): Promise<CacheAvailabilityState> {
+    const gitRemote = await getGitRemote();
+    if (!gitRemote) {
+      return { isAvailable: false, reason: 'No git remote found' };
+    }
+
+    return { isAvailable: true };
   }
 
   async getRepoDetails() {

--- a/packages/provider-github/src/lib/providerGitHub.ts
+++ b/packages/provider-github/src/lib/providerGitHub.ts
@@ -27,7 +27,7 @@ export class GitHubBuildCache implements RemoteBuildCache {
   async getAvailabilityState(): Promise<CacheAvailabilityState> {
     const gitRemote = await getGitRemote();
     if (!gitRemote) {
-      return { isAvailable: false, reason: 'No git remote found' };
+      return { isAvailable: false, reason: 'No git remote set.' };
     }
 
     return { isAvailable: true };

--- a/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
+++ b/packages/tools/src/lib/__tests__/remoteBuildCache.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest';
-import type { RemoteBuildCache } from '../build-cache/common.js';
+import type {
+  CacheAvailabilityState,
+  RemoteBuildCache,
+} from '../build-cache/common.js';
 
 const uploadMock = vi.fn();
 
@@ -10,6 +13,11 @@ class DummyRemoteCacheProvider implements RemoteBuildCache {
       this.name = options.name;
     }
   }
+
+  async getAvailabilityState(): Promise<CacheAvailabilityState> {
+    return { isAvailable: true };
+  }
+
   async list({ artifactName }: { artifactName: string }) {
     return [{ name: artifactName, url: '/path/to/dummy' }];
   }

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -17,6 +17,16 @@ export type LocalArtifact = {
   name: string;
 };
 
+export type CacheAvailabilityState =
+  | {
+      isAvailable: true;
+      reason?: undefined;
+    }
+  | {
+      isAvailable: false;
+      reason: string;
+    };
+
 /**
  * Interface for implementing remote build cache providers.
  * Remote cache providers allow storing and retrieving native build artifacts (e.g. APK, IPA)
@@ -25,6 +35,12 @@ export type LocalArtifact = {
 export interface RemoteBuildCache {
   /** Unique identifier for this cache provider, will be displayed in logs */
   name: string;
+
+  /**
+   * Check if the remote cache provider is enabled
+   * @returns True if the remote cache provider is enabled, false otherwise
+   */
+  getAvailabilityState(): Promise<CacheAvailabilityState>;
 
   /**
    * List available artifacts matching the given name pattern

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -66,6 +66,19 @@ To disable this warning, set the provider to null:
 
   loader.stop(`No local build cached. Checking ${remoteBuildCache.name}.`);
 
+  logger.info('remoteBuildCache', remoteBuildCache);
+
+  const availabilityState = await remoteBuildCache.getAvailabilityState();
+  logger.info('availabilityState', availabilityState);
+
+  if (!availabilityState.isAvailable) {
+    logger.warn(
+      `${remoteBuildCache.name} is not available: ${availabilityState.reason}`
+    );
+
+    return null;
+  }
+
   const localArtifactPath = getLocalArtifactPath(artifactName);
   const response = await remoteBuildCache.download({ artifactName });
   loader.start(`Downloading cached build from ${remoteBuildCache.name}`);

--- a/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
+++ b/packages/tools/src/lib/build-cache/fetchCachedBuild.ts
@@ -66,14 +66,10 @@ To disable this warning, set the provider to null:
 
   loader.stop(`No local build cached. Checking ${remoteBuildCache.name}.`);
 
-  logger.info('remoteBuildCache', remoteBuildCache);
-
   const availabilityState = await remoteBuildCache.getAvailabilityState();
-  logger.info('availabilityState', availabilityState);
-
   if (!availabilityState.isAvailable) {
     logger.warn(
-      `${remoteBuildCache.name} is not available: ${availabilityState.reason}`
+      `${remoteBuildCache.name} caching is not available: ${availabilityState.reason}`
     );
 
     return null;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes `run:ios`/`run:android` when new project was created with GitHub provider but does not yet have git remote.

Resolves #351

Before:
![CleanShot 2025-05-23 at 16 09 32@2x](https://github.com/user-attachments/assets/1eb84f80-6405-49d4-9736-3be582df7c76)

After: 
![CleanShot 2025-05-23 at 16 06 58@2x](https://github.com/user-attachments/assets/d65243ed-c1e0-4993-bc1e-1b95a16e528c)

### Repo

1. Create project straight from template (with GitHub provider)
2. Run `rnef run:ios` or `rnef run:android` 
3. It fails as there is no git remote set yet.

This PR logs warning and continues building locally.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
