### PR TITLE
docs: add update scripts step to RNC CLI migration guide 

### DIFF
--- a/.changeset/yellow-mangos-chew.md
+++ b/.changeset/yellow-mangos-chew.md
@@ -1,0 +1,5 @@
+---
+'rnef-docs': patch
+---
+
+Add update scripts step to RNC CLI migration guide

--- a/website/docs/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/docs/docs/getting-started/migrating-from-community-cli.mdx
@@ -4,7 +4,7 @@ import { PackageManagerTabs } from 'rspress/theme';
 
 1. Install dev dependencies:
 
-   <PackageManagerTabs command="install @rnef/cli @rnef/plugin-metro @rnef/platform-android @rnef/platform-ios" />
+   <PackageManagerTabs command="install -D @rnef/cli @rnef/plugin-metro @rnef/platform-android @rnef/platform-ios" />
 
 1. Remove `@react-native-community/cli` and related packages.
 

--- a/website/docs/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/docs/docs/getting-started/migrating-from-community-cli.mdx
@@ -113,8 +113,8 @@ import { PackageManagerTabs } from 'rspress/theme';
    {
      "scripts": {
        "start": "rnef start",
-       "run:android": "rnef run:android",
-       "run:ios": "rnef run:ios"
+       "android": "rnef run:android",
+       "ios": "rnef run:ios"
      }
    }
    ```

--- a/website/docs/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/docs/docs/getting-started/migrating-from-community-cli.mdx
@@ -107,6 +107,18 @@ import { PackageManagerTabs } from 'rspress/theme';
    git clean -fdx ios/ android/
    ```
 
+1. Update scripts in `package.json`:
+
+   ```json title="package.json"
+   {
+     "scripts": {
+       "start": "rnef start",
+       "run:android": "rnef run:android",
+       "run:ios": "rnef run:ios"
+     }
+   }
+   ```
+
 1. Run new commands:
 
    ```sh


### PR DESCRIPTION
### Summary

- [x] - mark RNEF deps as devDependencies
- [x] - add update scripts step to the migration guide 

### Test plan

n/a
