### PR TITLE
chore: use `default` condition everywhere in package exports

### DIFF
--- a/.changeset/hungry-worms-hammer.md
+++ b/.changeset/hungry-worms-hammer.md
@@ -1,0 +1,17 @@
+---
+'@rnef/plugin-brownfield-android': patch
+'@rnef/platform-apple-helpers': patch
+'@rnef/plugin-brownfield-ios': patch
+'@rnef/platform-android': patch
+'@rnef/provider-github': patch
+'@rnef/plugin-repack': patch
+'@rnef/platform-ios': patch
+'@rnef/plugin-metro': patch
+'@rnef/test-helpers': patch
+'@rnef/provider-s3': patch
+'@rnef/create-app': patch
+'@rnef/config': patch
+'@rnef/tools': patch
+---
+
+Use "default" condition instead of "import" in package exports across packages

--- a/.changeset/hungry-worms-hammer.md
+++ b/.changeset/hungry-worms-hammer.md
@@ -14,4 +14,4 @@
 '@rnef/tools': patch
 ---
 
-Use "default" condition instead of "import" in package exports across packages
+chore: use "default" condition instead of "import" in package exports across packages

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/platform-apple-helpers/package.json
+++ b/packages/platform-apple-helpers/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/plugin-brownfield-android/package.json
+++ b/packages/plugin-brownfield-android/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/plugin-brownfield-ios/package.json
+++ b/packages/plugin-brownfield-ios/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/plugin-repack/package.json
+++ b/packages/plugin-repack/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/provider-github/package.json
+++ b/packages/provider-github/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"

--- a/packages/provider-s3/package.json
+++ b/packages/provider-s3/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "import": "./dist/src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

With `require(ESM)` available in newer node version there is no reason to artificially limit importing through ESM imports only - to reflect that, I've changed the `import` condition to `default` which will always be taken into account regardless of how packages are imported.

cc @satya164 

### Test plan

n/a
