### PR TITLE
fix: bring back using id/name before setting generic destination

### DIFF
--- a/.changeset/thin-melons-shave.md
+++ b/.changeset/thin-melons-shave.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: bring back using id/name before setting generic destination

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -133,12 +133,6 @@ function determineDestinations({
   udid,
   deviceName,
 }: DetermineDestinationsArgs): string[] {
-  if (args.destination && args.destination.length > 0) {
-    return args.destination.map((destination) =>
-      resolveDestination(destination, platformName)
-    );
-  }
-
   if ('catalyst' in args && args.catalyst) {
     return ['platform=macOS,variant=Mac Catalyst'];
   }
@@ -149,6 +143,12 @@ function determineDestinations({
 
   if (deviceName) {
     return [`name=${deviceName}`];
+  }
+
+  if (args.destination && args.destination.length > 0) {
+    return args.destination.map((destination) =>
+      resolveDestination(destination, platformName)
+    );
   }
 
   return [getGenericDestination(platformName, 'device')];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When `udid` or `name` are available, we should always set these instead of generic destination for `xcodebuild`.

cc @mdjastrzebski @troZee 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
