### PR TITLE
perf: avoid double invoking of native deps in config command

### DIFF
--- a/.changeset/selfish-trains-wash.md
+++ b/.changeset/selfish-trains-wash.md
@@ -1,0 +1,5 @@
+---
+'@rnef/cli': patch
+---
+
+perf: avoid double invoking of native deps in config command

--- a/packages/cli/src/lib/plugins/logConfig.ts
+++ b/packages/cli/src/lib/plugins/logConfig.ts
@@ -18,12 +18,16 @@ function filterConfig(config: Config) {
   // but in our case we don't install `@react-native-community/cli-platform-*` as a dependencies
   // so the config.platforms key is empty, which makes autolinking treat it as a dependency.
   delete filtered.dependencies['react-native'];
+  const dependencies: Record<string, DependencyConfig> = {};
   Object.keys(filtered.dependencies).forEach((item) => {
-    if (!isValidRNDependency(filtered.dependencies[item])) {
-      delete filtered.dependencies[item];
+    if (isValidRNDependency(filtered.dependencies[item])) {
+      dependencies[item] = filtered.dependencies[item];
     }
   });
-  return filtered;
+  return {
+    ...filtered,
+    dependencies,
+  };
 }
 
 export const logConfig = async (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When calling `config`, the native dependencies getters are invoked twice: first for the filtering pass, and then for stringily. Changed the filtering logic to push resolved getters of native deps instead of removing non-native dependencies.

Overall, this should improve config and fingerprint perf a little.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
