### PR TITLE
fix: use file:// URLs for ESM config on Windows

### DIFF
--- a/.changeset/pink-trees-wonder.md
+++ b/.changeset/pink-trees-wonder.md
@@ -1,0 +1,5 @@
+---
+'@rnef/config': patch
+---
+
+fix: use file:// URLs for ESM config on Windows

--- a/packages/config/src/lib/config.ts
+++ b/packages/config/src/lib/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { FingerprintSources, RemoteBuildCache } from '@rnef/tools';
 import { color, logger } from '@rnef/tools';
 import type { ValidationError } from 'joi';
@@ -97,7 +98,7 @@ const importUp = async (
       let config: ConfigType;
 
       if (ext === '.mjs') {
-        config = await import(filePathWithExt).then((module) => module.default);
+        config = await import(pathToFileURL(filePathWithExt).href).then((module) => module.default);
       } else {
         const require = createRequire(import.meta.url);
         config = require(filePathWithExt);


### PR DESCRIPTION
### Summary

fix: support file:// URLs for ESM config loading on Windows (fixes #313)

This PR ensures that ESM config files are loaded using file:// URLs instead of Windows paths, solving the ERR_UNSUPPORTED_ESM_URL_SCHEME error when running `rnef start` on Windows. This allows Metro and the CLI to work correctly in test apps on Windows.

Issue: https://github.com/callstack/rnef/issues/313

### Test plan

1. Build the branch with `pnpm build`.
2. In a test app on Windows, link local RNEF packages:
  `pnpm link @rnef/cli @rnef/platform-android @rnef/platform-ios @rnef/plugin-metro`
4. Run `pnpm rnef start` in the test app.
5. Metro dev server should start without ERR_UNSUPPORTED_ESM_URL_SCHEME.

 Before:
![image](https://github.com/user-attachments/assets/80182ec7-cd6b-4e94-bed5-e3e15ed4a861)

After:
![image](https://github.com/user-attachments/assets/55fa3c7e-7ab3-437b-b017-77b4ea815bf0)

