### PR TITLE
chore: throw more information when fetch github fails

### DIFF
--- a/.changeset/giant-toys-film.md
+++ b/.changeset/giant-toys-film.md
@@ -1,0 +1,6 @@
+---
+'@rnef/platform-apple-helpers': patch
+'@rnef/provider-github': patch
+---
+
+chore: throw more information when fetch github fails

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -79,7 +79,9 @@ export const createRun = async ({
         binaryPath = cachedBuild.binaryPath;
       }
     } catch (error) {
-      logger.warn((error as RnefError).message);
+      const message = (error as RnefError).message;
+      const cause = (error as RnefError).cause;
+      logger.warn(message, cause ? `\nCause: ${cause.toString()}` : '');
       const shouldContinueWithLocalBuild = await promptConfirm({
         message: 'Would you like to continue with local build?',
         confirmLabel: 'Yes',

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -58,7 +58,9 @@ export async function fetchGitHubArtifactsByName(
         }
         data = await response.json();
       } catch (error) {
-        throw new Error(`Error fetching artifacts: ${error}`);
+        throw new Error(
+          `Error fetching artifacts from ${color.underline(url)}: ${error}`
+        );
       }
 
       const artifacts = data.artifacts


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Set a bit more information when GitHub fails to fetch for some reason.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
