### PR TITLE
fix: set build-folder for build settings as well

### DIFF
--- a/.changeset/poor-lions-carry.md
+++ b/.changeset/poor-lions-carry.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: set build-folder for build settings as well

--- a/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
@@ -17,6 +17,7 @@ export async function getBuildSettings({
   destinations,
   scheme,
   target,
+  buildFolder,
 }: {
   xcodeProject: XcodeProjectInfo;
   sourceDir: string;
@@ -25,6 +26,7 @@ export async function getBuildSettings({
   destinations: string[];
   scheme: string;
   target?: string;
+  buildFolder?: string;
 }): Promise<{ appPath: string; infoPlistPath: string }> {
   const destination = destinations[0];
   const sdk = destination.match(/simulator/i)
@@ -36,6 +38,7 @@ export async function getBuildSettings({
     [
       xcodeProject.isWorkspace ? '-workspace' : '-project',
       xcodeProject.name,
+      ...(buildFolder ? ['-derivedDataPath', buildFolder] : []),
       '-scheme',
       scheme,
       '-configuration',

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -107,6 +107,7 @@ export async function buildApp({
     destinations,
     scheme,
     target: args.target,
+    buildFolder: args.buildFolder,
   });
   const appPath = buildSettings.appPath;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes saving to local cache with custom `--build-folder` as it wasn't respected by the `getBuildSettings` helper.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
