### PR TITLE
fix: don't delete from s3 if --all-but-latest is provided

### DIFF
--- a/.changeset/curly-cups-float.md
+++ b/.changeset/curly-cups-float.md
@@ -1,0 +1,5 @@
+---
+'@rnef/provider-s3': patch
+---
+
+fix: don't delete from s3 if --all-but-latest is provided

--- a/packages/provider-s3/src/lib/providerS3.ts
+++ b/packages/provider-s3/src/lib/providerS3.ts
@@ -108,9 +108,15 @@ export class S3BuildCache implements RemoteBuildCache {
 
   async delete({
     artifactName,
+    skipLatest,
   }: {
     artifactName: string;
+    skipLatest?: boolean;
   }): Promise<RemoteArtifact[]> {
+    if (skipLatest) {
+      // Artifacts on S3 are unique by name, so skipping latest means we don't delete anything
+      return [];
+    }
     await this.s3.send(
       new clientS3.DeleteObjectCommand({
         Bucket: this.bucket,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Support `remote-cache delete --all-but-latest` flag for S3 provider (where it means to not delete at all)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
