### PR TITLE
feat: support hermes sourcemap compose

### DIFF
--- a/packages/platform-android/src/lib/commands/signAndroid/bundle.ts
+++ b/packages/platform-android/src/lib/commands/signAndroid/bundle.ts
@@ -64,5 +64,8 @@ export async function buildJsBundle(options: BuildJsBundleOptions) {
     return;
   }
 
-  await runHermes({ bundleOutputPath: options.bundleOutputPath });
+  await runHermes({
+    bundleOutputPath: options.bundleOutputPath,
+    sourcemapOutputPath: options.sourcemapOutputPath,
+  });
 }

--- a/packages/platform-apple-helpers/src/lib/commands/sign/bundle.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/sign/bundle.ts
@@ -12,6 +12,7 @@ type BuildJsBundleOptions = {
   bundleOutputPath: string;
   assetsDestPath: string;
   useHermes?: boolean;
+  sourcemapOutputPath?: string;
 };
 
 /**
@@ -41,6 +42,7 @@ export async function buildJsBundle(options: BuildJsBundleOptions) {
     options.bundleOutputPath,
     '--assets-dest',
     options.assetsDestPath,
+    ...(options.sourcemapOutputPath ? ['--sourcemap-output', options.sourcemapOutputPath] : []),
   ];
   try {
     await spawn('rnef', rnefBundleArgs, { preferLocal: true });
@@ -54,5 +56,8 @@ export async function buildJsBundle(options: BuildJsBundleOptions) {
     return;
   }
 
-  await runHermes({ bundleOutputPath: options.bundleOutputPath });
+  await runHermes({
+    bundleOutputPath: options.bundleOutputPath,
+    sourcemapOutputPath: options.sourcemapOutputPath,
+  });
 }

--- a/packages/plugin-metro/src/lib/bundle/command.ts
+++ b/packages/plugin-metro/src/lib/bundle/command.ts
@@ -62,7 +62,10 @@ export function registerBundleCommand(api: PluginApi) {
       if (args.hermes) {
         const loader = spinner();
         loader.start('Running Hermes compiler...');
-        await runHermes({ bundleOutputPath: args.bundleOutput });
+        await runHermes({
+          bundleOutputPath: args.bundleOutput,
+          sourcemapOutputPath: args.sourcemapOutput,
+        });
         loader.stop(
           `Hermes bytecode bundle created at: ${color.cyan(args.bundleOutput)}`
         );

--- a/packages/plugin-repack/src/lib/pluginRepack.ts
+++ b/packages/plugin-repack/src/lib/pluginRepack.ts
@@ -90,7 +90,10 @@ export const pluginRepack =
 
           const loader = spinner();
           loader.start('Running Hermes compiler...');
-          await runHermes({ bundleOutputPath: args.bundleOutput });
+          await runHermes({
+            bundleOutputPath: args.bundleOutput,
+            sourcemapOutputPath: args.sourcemapOutput,
+          });
           loader.stop(
             `Hermes bytecode bundle created at: ${color.cyan(
               args.bundleOutput


### PR DESCRIPTION
# Add Hermes Sourcemap Composition Support to RNEF

## Summary

When building with Hermes through RNEF and generating sourcemaps, a **compose operation** is required to properly handle sourcemap compatibility.

According to the [[official Sentry documentation for React Native Hermes sourcemaps](https://docs.sentry.io/platforms/react-native/sourcemaps/uploading/hermes/)](https://docs.sentry.io/platforms/react-native/sourcemaps/uploading/hermes/):

![Sentry Hermes Sourcemap Documentation](https://github.com/user-attachments/assets/2d89822d-6756-4258-b5a2-cbf1a7797f74)

The documentation clearly shows that **Hermes sourcemaps must be composed with the original sourcemaps**. This is a React Native specification requirement, not a Sentry-specific feature.

### Responsibilities

- **RNEF's responsibility**: When building with Hermes and generating sourcemaps, RNEF should handle the sourcemap composition process
- **Sentry's responsibility**: Injecting `debug_id` into bundles is Sentry's concern and should not be handled by RNEF

This means that if RNEF builds with Hermes and generates sourcemaps, it must **at minimum** perform the compose operation to meet React Native specifications.

## Background

After composition, when Sentry's `debugId` is injected into the bundle, the sourcemaps can be uploaded to Sentry to enable proper stack trace debugging.

## Test Plan

This change was tested using **RNEF + Re.Pack + Hot Updater** for OTA bundle updates with automatic sourcemap uploading.

### Prerequisites

Since Re.Pack doesn't natively support Sentry integration, I created a custom plugin to replicate the functionality that Metro provides:

**Standard Metro Configuration:**
```js
const { getDefaultConfig } = require("@react-native/metro-config");
const { withSentryConfig } = require("@sentry/react-native/metro");
const config = getDefaultConfig(__dirname);
module.exports = withSentryConfig(config);
```

This Metro configuration injects Sentry's `debug_id` into bundles. See: [[Sentry Metro Setup Documentation](https://docs.sentry.io/platforms/react-native/manual-setup/metro/)](https://docs.sentry.io/platforms/react-native/manual-setup/metro/)

**Re.Pack Equivalent:**
Since Re.Pack doesn't support this natively, I created [`[repack-plugin-sentry](https://github.com/gronxb/repack-plugin-sentry)`](https://github.com/gronxb/repack-plugin-sentry) to provide the same functionality.

**Project Configuration:**

`rspack.config.js`:
```tsx
import { SentryDebugIdPlugin } from "repack-plugin-sentry";

plugins: [
  new Repack.RepackPlugin(),
  new HotUpdaterPlugin(),
  new rspack.EnvironmentPlugin({
    HOT_UPDATER_SUPABASE_URL: JSON.stringify(
      process.env.HOT_UPDATER_SUPABASE_URL,
    ),
  }),
  new SentryDebugIdPlugin(), // Equivalent to Metro's withSentry configuration
],
```

`hot-updater.config.ts`:
```ts
import { rnef } from "@hot-updater/rnef";
import { withSentry } from "@hot-updater/sentry-plugin";
import { defineConfig } from "hot-updater";
import "dotenv/config";

export default defineConfig({
  build: withSentry(
    rnef({
      sourcemap: true,
    }),
    {
      authToken: process.env.SENTRY_AUTH_TOKEN!,
      org: "hot-updater",
      project: "react-native",
    },
  ),
  // ... other config
});
```

The `withSentry` wrapper handles sourcemap uploading to Sentry during OTA deployment.

### Test Results

#### ✅ Without Hermes (RNEF + Re.Pack)

![Working without Hermes](https://github.com/user-attachments/assets/c235bdaa-c89f-4bbe-8452-119a5707732d)

**Result**: Works correctly even without this PR.

#### ❌ With Hermes - Before This PR (RNEF + Re.Pack)

![Failed Sentry upload](https://github.com/user-attachments/assets/0599d0af-698c-44d4-90b7-45e73c9609a2)

**Result**: Sentry upload fails due to sourcemap mismatch.

#### ✅ With Hermes - After This PR (RNEF + Re.Pack)

![Successful Hermes sourcemap](https://github.com/user-attachments/assets/6afda678-7235-4da2-86dd-972920c0b81b)

**Result**: 
- Hermes sourcemaps are properly generated and composed
- When `debugId` is correctly injected by other tools, stack traces work perfectly
- All functionality operates as expected

## Conclusion

This PR ensures RNEF properly handles Hermes sourcemap composition according to React Native specifications, enabling proper integration with debugging tools like Sentry.