### PR TITLE
fix: filter null fingerprint sources; output sources to stderr when --raw

### DIFF
--- a/.changeset/fifty-donkeys-joke.md
+++ b/.changeset/fifty-donkeys-joke.md
@@ -1,0 +1,5 @@
+---
+'@rnef/cli': patch
+---
+
+fix: filter null fingerprint sources; output sources to stderr when --raw

--- a/packages/cli/src/lib/plugins/fingerprint.ts
+++ b/packages/cli/src/lib/plugins/fingerprint.ts
@@ -25,13 +25,24 @@ export async function nativeFingerprintCommand(
   const platform = options.platform;
   const readablePlatformName = platform === 'ios' ? 'iOS' : 'Android';
 
-  if (options?.raw || !isInteractive()) {
+  if (options.raw || !isInteractive()) {
     const fingerprint = await nativeFingerprint(path, {
       platform,
       extraSources,
       ignorePaths,
     });
     console.log(fingerprint.hash);
+    // log sources to stderr to avoid polluting the standard output
+    console.error(
+      JSON.stringify(
+        {
+          hash: fingerprint.hash,
+          sources: fingerprint.sources.filter((source) => source.hash != null),
+        },
+        null,
+        2
+      )
+    );
     return;
   }
 
@@ -50,7 +61,14 @@ export async function nativeFingerprintCommand(
 
   loader.stop(`Fingerprint calculated: ${fingerprint.hash}`);
 
-  logger.debug('Sources:', JSON.stringify(fingerprint.sources, null, 2));
+  logger.debug(
+    'Sources:',
+    JSON.stringify(
+      fingerprint.sources.filter((source) => source.hash != null),
+      null,
+      2
+    )
+  );
   logger.debug(`Duration: ${(duration / 1000).toFixed(1)}s`);
 
   outro('Success 🎉.');


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We don't need to show null sources (which, if I understand correctly, are due to excluded sources like node_modules), so filtering them out from the output.
When in `--raw` we'll now display the sources as JSON in stderr so we can still use stdout for scripting and display the sources for debugging purposes.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
