### PR TITLE
feat: extract and inject debugId in hermes sourcemaps

### DIFF
--- a/.changeset/shiny-apes-rhyme.md
+++ b/.changeset/shiny-apes-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@rnef/tools': patch
+---
+
+feat: extract and inject debugId in hermes sourcemaps

--- a/packages/tools/src/lib/hermes.ts
+++ b/packages/tools/src/lib/hermes.ts
@@ -59,14 +59,8 @@ function injectDebugId(sourceMapPath: string, debugId: string) {
   try {
     const sourceMapContent = fs.readFileSync(sourceMapPath, 'utf-8');
     const sourceMap = JSON.parse(sourceMapContent);
-    
-    // Create a new object with debugId at the top level
-    const newSourceMap = {
-      debugId,
-      ...sourceMap
-    };
-    
-    fs.writeFileSync(sourceMapPath, JSON.stringify(newSourceMap));
+    sourceMap.debugId = debugId;
+    fs.writeFileSync(sourceMapPath, JSON.stringify(sourceMap));
   } catch {
     throw new RnefError(
       `Failed to inject debugId into sourcemap: ${sourceMapPath}`


### PR DESCRIPTION
### Summary

Related to #404

After conducting several tests, I discovered an issue with the previous implementation. While the previous PR excluded `debugId` insertion (considering it Sentry's responsibility), it turns out to be necessary.

**Root Cause**: Even when the original source map contains a `debugId`, it gets lost during the compose sourcemap process.

The `debugId` follows the TC39 Stage 2 proposal specification:
https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md

I've also verified that Expo handles `debugId` processing and included their implementation as reference:
https://github.com/expo/expo/blob/997aefa7271a9fd49f83beba541b8026bb8592ae/packages/%40expo/metro-config/src/serializer/serializeChunks.ts#L499-L511

### Problem Statement

When using Hermes bytecode compilation, the source map composition process strips the `debugId` from the final source map, breaking debug symbol resolution for error tracking services like Sentry.

### Test Plan

**Environment**: RNEF + Re.Pack + https://github.com/gronxb/repack-plugin-sentry

**Configuration** (`rspack.config.js`):
```js
plugins: [
    new Repack.RepackPlugin(),
    new SentryDebugIdPlugin(),
],
```

#### Test Case 1: Without Hermes (Before Fix)
**Command**: 
```bash
pnpm rnef bundle --entry-file index.js --platform ios --bundle-output dist/index.ios.bundle --sourcemap-output dist/index.ios.bundle.map
```

**Result**: ✅ Source map contains `debugId` (no composition process, so `debugId` is preserved)

![Without Hermes - debugId preserved](https://github.com/user-attachments/assets/75c2d475-a892-4ae1-924e-36c5526d5b0c)

#### Test Case 2: With Hermes (Before Fix)
**Command**: 
```bash
pnpm rnef bundle --entry-file index.js --platform ios --bundle-output dist/index.ios.bundle --sourcemap-output dist/index.ios.bundle.map --hermes
```

**Result**: ❌ `debugId` is missing from the final source map after compose-sourcemap process

![With Hermes Before Fix - debugId missing](https://github.com/user-attachments/assets/1ba85f10-52c2-416a-b880-d23d21e7ac2a)

#### Test Case 3: With Hermes (After Fix)
**Command**: 
```bash
pnpm rnef bundle --entry-file index.js --platform ios --bundle-output dist/index.ios.bundle --sourcemap-output dist/index.ios.bundle.map --hermes
```

**Result**: ✅ `debugId` is preserved in the final source map after compose-sourcemap process

![With Hermes After Fix - debugId preserved](https://github.com/user-attachments/assets/e975a150-f594-4e5d-8ee9-b73663684255)

### Expected Behavior

When the original source map contains a `debugId`, it should be preserved in the final composed source map after Hermes bytecode compilation, ensuring proper debug symbol resolution for error tracking and monitoring services.