### PR TITLE
docs: add missing package name on Android

### DIFF
--- a/website/docs/docs/brownfield/android.md
+++ b/website/docs/docs/brownfield/android.md
@@ -73,6 +73,8 @@ After adding these, sync your project and run `./gradlew assembleRelease` to ver
 Create a new file called `ReactNativeHostManager.kt` in your `rnbrownfield` module:
 
 ```kotlin
+package com.callstack.rnbrownfield // If you used a different package name when creating the library, change it here
+
 import android.app.Application
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
@@ -169,6 +171,8 @@ android {
 Create a new file called `RNViewFactory.kt` to wrap your React Native UI in a `FrameLayout`:
 
 ```kotlin title="RNViewFactory.kt"
+package com.callstack.rnbrownfield // If you used a different package name when creating the library, change it here
+
 import android.content.Context
 import android.os.Bundle
 import android.widget.FrameLayout


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add missing package name to Android docs.

Without the package declaration, `BuildConfig` cannot be found, and the build command `./gradlew :rnbrownfield:assembleRelease` will fail.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
