### PR TITLE
fix: always pipe stderr

### DIFF
--- a/packages/tools/src/lib/spawn.ts
+++ b/packages/tools/src/lib/spawn.ts
@@ -7,8 +7,12 @@ export function spawn(
   args?: readonly string[],
   options?: Options
 ): Subprocess {
+  const defualtStream = logger.isVerbose() ? 'inherit' : 'pipe';
   const defaultOptions: Options = {
-    stdio: logger.isVerbose() ? 'inherit' : 'pipe',
+    stdin: defualtStream,
+    stdout: defualtStream,
+    // Always 'pipe' stderr to handle errors properly down the line
+    stderr: 'pipe',
   };
   logger.debug(`Running: ${file}`, ...(args ?? []));
   const childProcess = nanoSpawn(file, args, { ...defaultOptions, ...options });


### PR DESCRIPTION
### Summary

Always pipe the `stderr` stream to handle errors properly in `verbose` mode.

