### PR TITLE
feat: handle 404 from github gracefully

### DIFF
--- a/.changeset/tender-readers-confess.md
+++ b/.changeset/tender-readers-confess.md
@@ -1,0 +1,5 @@
+---
+'@rnef/provider-github': patch
+---
+
+feat: handle 404 from github gracefully

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -91,7 +91,23 @@ Update the token under "${color.bold(
         )}" key in ${color.cyan('rnef.config.mjs')} config file.
 
 📘 Read more about generating a new token: ${color.cyan(
-          'https://www.rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
+          'https://rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
+        )}`
+      );
+    }
+    if ((error as { message: string }).message.includes('404 Not Found')) {
+      throw new RnefError(
+        `Failed to fetch GitHub artifacts due to "404 Not Found" error. This can happen for the following reasons:
+- permission mismatch between your GitHub Personal Access Token and the repository
+- you're blocked by the owner of the repository
+- repository address is incorrect
+
+Make sure the repository information and token under "${color.bold(
+          'remoteCacheProvider'
+        )}" key in ${color.cyan('rnef.config.mjs')} config file is valid.
+
+📘 Read more about generating a new token: ${color.cyan(
+          'https://rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
         )}`
       );
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We can provide a better error when GitHub fails with 404, which may mean the user provided token with incompatible permissions.

### Test plan

<img width="787" alt="image" src="https://github.com/user-attachments/assets/c6dc9cb9-8781-4f2c-8558-71f2ef8afc0b" />

