### PR TITLE
feat: add `--app` flag to `sign:ios` to support replacing js bundle in APP files

### DIFF
--- a/.changeset/quick-pianos-draw.md
+++ b/.changeset/quick-pianos-draw.md
@@ -1,0 +1,8 @@
+---
+'@rnef/platform-apple-helpers': patch
+'@rnef/platform-android': patch
+'@rnef/platform-ios': patch
+'rnef-docs': patch
+---
+
+feat: add '--app' flag to sign:ios to support replacing js bundle in APP files

--- a/packages/platform-android/src/lib/commands/signAndroid/command.ts
+++ b/packages/platform-android/src/lib/commands/signAndroid/command.ts
@@ -63,7 +63,7 @@ const OPTIONS = [
 export const registerSignCommand = (api: PluginApi) => {
   api.registerCommand({
     name: 'sign:android',
-    description: 'Sign the Android app',
+    description: 'Sign the Android app with modified JS bundle.',
     args: ARGUMENTS,
     options: OPTIONS,
     action: async (apkPath, flags: SignFlags) => {

--- a/packages/platform-apple-helpers/src/lib/commands/sign/modifyApp.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/sign/modifyApp.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import {
+  color,
+  intro,
+  logger,
+  outro,
+  relativeToCwd,
+  RnefError,
+  spinner,
+} from '@rnef/tools';
+import { buildJsBundle } from './bundle.js';
+import { getAppPaths } from './utils.js';
+
+export type ModifyAppOptions = {
+  appPath: string;
+  outputPath?: string;
+  buildJsBundle?: boolean;
+  jsBundlePath?: string;
+  useHermes?: boolean;
+};
+
+export const modifyApp = async (options: ModifyAppOptions) => {
+  validateOptions(options);
+
+  intro(`Modifying APP file`);
+
+  const loader = spinner();
+
+  // 1. Copy APP file to output path if provided
+  if (options.outputPath) {
+    try {
+      fs.cpSync(options.appPath, options.outputPath, { recursive: true });
+    } catch (error) {
+      throw new RnefError(
+        `Failed to copy APP file to ${color.cyan(
+          relativeToCwd(options.outputPath)
+        )}.`,
+        { cause: error }
+      );
+    }
+  }
+
+  // 2. Make APP content changes if needed: build or swap JS bundle
+  const appPaths = getAppPaths(options.outputPath ?? options.appPath);
+  if (options.buildJsBundle) {
+    loader.start('Building JS bundle');
+    await buildJsBundle({
+      bundleOutputPath: appPaths.jsBundle,
+      assetsDestPath: appPaths.assetsDest,
+      useHermes: options.useHermes ?? true,
+    });
+    loader.stop(
+      `Built JS bundle: ${color.cyan(relativeToCwd(appPaths.jsBundle))}`
+    );
+  } else if (options.jsBundlePath) {
+    loader.start('Replacing JS bundle');
+    fs.copyFileSync(options.jsBundlePath, appPaths.jsBundle);
+    loader.stop(
+      `Replaced JS bundle with ${color.cyan(
+        relativeToCwd(options.jsBundlePath)
+      )}`
+    );
+  }
+
+  logger.log(
+    `Modified APP file with new JS bundle. Available at: ${color.cyan(
+      relativeToCwd(options.outputPath ?? options.appPath)
+    )}`
+  );
+
+  outro('Success 🎉.');
+};
+
+function validateOptions(options: ModifyAppOptions) {
+  if (!fs.existsSync(options.appPath)) {
+    throw new RnefError(
+      `APP file (directory) not found at "${options.appPath}". Please provide a correct path.`
+    );
+  }
+
+  if (options.buildJsBundle && options.jsBundlePath) {
+    throw new RnefError(
+      'The "--build-jsbundle" flag is incompatible with "--jsbundle". Pick one.'
+    );
+  }
+
+  if (options.jsBundlePath && !fs.existsSync(options.jsBundlePath)) {
+    throw new RnefError(
+      `JS bundle file not found at "${options.jsBundlePath}". Please provide a correct path.`
+    );
+  }
+}

--- a/packages/platform-apple-helpers/src/lib/index.ts
+++ b/packages/platform-apple-helpers/src/lib/index.ts
@@ -3,6 +3,7 @@ export { createRun } from './commands/run/createRun.js';
 export { getBuildOptions, BuildFlags } from './commands/build/buildOptions.js';
 export { getRunOptions, RunFlags } from './commands/run/runOptions.js';
 export { modifyIpa, type ModifyIpaOptions } from './commands/sign/modifyIpa.js';
+export { modifyApp, type ModifyAppOptions } from './commands/sign/modifyApp.js';
 export { genericDestinations } from './utils/destionation.js';
 export { getBuildPaths } from './utils/getBuildPaths.js';
 export { getInfo } from './utils/getInfo.js';

--- a/packages/platform-ios/src/lib/commands/signIos.ts
+++ b/packages/platform-ios/src/lib/commands/signIos.ts
@@ -1,9 +1,8 @@
 import type { PluginApi } from '@rnef/config';
-import { modifyIpa } from '@rnef/platform-apple-helpers';
+import { modifyApp, modifyIpa } from '@rnef/platform-apple-helpers';
 
 export type SignFlags = {
-  verbose?: boolean;
-  ipa: string;
+  app: string;
   output?: string;
   identity?: string;
   buildJsbundle?: boolean;
@@ -13,19 +12,20 @@ export type SignFlags = {
 
 const ARGUMENTS = [
   {
-    name: 'ipa',
-    description: 'IPA file path',
+    name: 'binaryPath',
+    description: 'Path to the IPA or APP file.',
   },
 ];
 
 const OPTIONS = [
   {
-    name: '--verbose',
-    description: '',
+    name: '--app',
+    description: 'Modify APP file (directory) instead of IPA file. No signing is done.',
   },
   {
     name: '--identity <string>',
-    description: 'Certificate Identity name to use for code signing, e.g. "Apple Distribution: Your Team (HFJASKHDDS)".',
+    description:
+      'Certificate Identity name to use for code signing, e.g. "Apple Distribution: Your Team (HFJASKHDDS)".',
   },
   {
     name: '--output <string>',
@@ -48,19 +48,29 @@ const OPTIONS = [
 export const registerSignCommand = (api: PluginApi) => {
   api.registerCommand({
     name: 'sign:ios',
-    description: 'Sign the iOS app',
+    description: 'Sign the iOS app (IPA or APP file) with modified JS bundle.',
     args: ARGUMENTS,
     options: OPTIONS,
-    action: async (ipaPath, flags: SignFlags) => {
-      await modifyIpa({
-        platformName: 'ios',
-        ipaPath,
-        identity: flags.identity,
-        outputPath: flags.output,
-        buildJsBundle: flags.buildJsbundle,
-        jsBundlePath: flags.jsbundle,
-        useHermes: !flags.noHermes,
-      });
+    action: async (binaryPath, flags: SignFlags) => {
+      if (flags.app) {
+        await modifyApp({
+          appPath: binaryPath,
+          outputPath: flags.output,
+          buildJsBundle: flags.buildJsbundle,
+          jsBundlePath: flags.jsbundle,
+          useHermes: !flags.noHermes,
+        });
+      } else {
+        await modifyIpa({
+          platformName: 'ios',
+          ipaPath: binaryPath,
+          identity: flags.identity,
+          outputPath: flags.output,
+          buildJsBundle: flags.buildJsbundle,
+          jsBundlePath: flags.jsbundle,
+          useHermes: !flags.noHermes,
+        });
+      }
     },
   });
 };

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -162,15 +162,20 @@ The build cache is populated either by a local build or when downloaded frome re
 
 ### `rnef sign:ios` Options
 
-The `sign:ios` command signs your iOS app with certificates and provisioning profiles, producing a signed IPA file ready for distribution.
+The `sign:ios` command either signs your iOS app with certificates and provisioning profiles, producing a signed IPA file ready for distribution, or modifies APP file without signing. It allows for replacing the JS bundle with a new version.
 
-| Option                | Description                                |
-| :-------------------- | :----------------------------------------- |
-| `--identity <string>` | Certificate Identity name for code signing |
-| `--output <string>`   | Path to output IPA file                    |
-| `--build-jsbundle`    | Build JS bundle before signing             |
-| `--jsbundle <string>` | Path to JS bundle to apply before signing  |
-| `--no-hermes`         | Don't use Hermes for JS bundle             |
+| Argument     | Description                 |
+| :----------- | :-------------------------- |
+| `binaryPath` | Path to the IPA or APP file |
+
+| Option                | Description                                                         |
+| :-------------------- | :------------------------------------------------------------------ |
+| `--app`               | Modify APP file (directory) instead of IPA file. No signing is done |
+| `--identity <string>` | Certificate Identity name for code signing                          |
+| `--output <string>`   | Path to output IPA file                                             |
+| `--build-jsbundle`    | Build JS bundle before signing                                      |
+| `--jsbundle <string>` | Path to JS bundle to apply before signing                           |
+| `--no-hermes`         | Don't use Hermes for JS bundle                                      |
 
 ### `rnef build:android` Options
 
@@ -205,7 +210,11 @@ Same as for `build:android` and:
 
 ### `rnef sign:android` Options
 
-The `sign:android` command signs your Android app with a keystore, producing a signed APK file ready for distribution.
+The `sign:android` command signs your Android app with a keystore, producing a signed APK file ready for distribution. It allows for replacing the JS bundle with a new version.
+
+| Argument     | Description          |
+| :----------- | :------------------- |
+| `binaryPath` | Path to the APK file |
 
 | Option                         | Description                               |
 | :----------------------------- | :---------------------------------------- |


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds `--app` flag to `sign:ios` command, allowing it to modify the .app files with a new bundle, when passed with `--build-jsbundle` or `--jsbundle` flags.

Usage:
```
rnef sign:ios --app <path-to-release-app-file> --build-jsbundle
```

Not entirely happy with the naming, as there's no signing for iOS in this case.

Fixes #405 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
