### PR TITLE
fix: make brownfield plugin optional; update dep; add android

### DIFF
--- a/.changeset/pink-jobs-destroy.md
+++ b/.changeset/pink-jobs-destroy.md
@@ -1,0 +1,6 @@
+---
+'@rnef/plugin-brownfield-ios': patch
+'@rnef/create-app': patch
+---
+
+fix: make brownfield plugin optional; update dep; add android

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,2 @@
-link-workspace-packages=true
-auto-install-peers=true
-package-manager-strict=true
-package-manager-strict-version=true
+//localhost:4873/:_authToken=secretToken
+registry=http://localhost:4873

--- a/packages/create-app/src/lib/templates.ts
+++ b/packages/create-app/src/lib/templates.ts
@@ -41,6 +41,14 @@ export const PLUGINS: TemplateInfo[] = [
     directory: 'template',
     importName: 'pluginBrownfieldIos',
   },
+  {
+    type: 'npm',
+    name: 'brownfield-android',
+    packageName: '@rnef/plugin-brownfield-android',
+    version: 'latest',
+    directory: 'template',
+    importName: 'pluginBrownfieldAndroid',
+  },
 ];
 
 export const BUNDLERS: TemplateInfo[] = [

--- a/packages/create-app/src/lib/utils/prompts.ts
+++ b/packages/create-app/src/lib/utils/prompts.ts
@@ -131,12 +131,12 @@ export function promptPlugins(
 
   return promptMultiselect({
     message: 'Select plugins:',
-    initialValues: [plugins[0]],
     // @ts-expect-error todo fixup type
     options: plugins.map((plugin) => ({
       value: plugin,
       label: plugin.name,
     })),
+    required: false,
   });
 }
 

--- a/packages/plugin-brownfield-ios/template/package.json
+++ b/packages/plugin-brownfield-ios/template/package.json
@@ -4,7 +4,7 @@
     "package:ios": "rnef package:ios --scheme HelloWorldReact --configuration Release"
   },
   "dependencies": {
-    "@callstack/react-native-brownfield": "1.0.1"
+    "@callstack/react-native-brownfield": "^1.1.0"
   },
   "devDependencies": {
     "@rnef/plugin-brownfield-ios": "^0.7.27"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Pass `required: false` to clack's `multiselect` so that we can allow for empty selection. Without that, brownfield plugin is essentially required, which is a regression.

Additionally I've updated the `@callstack/react-native-brownfield` dependency to latest (fixes a bug), and added Android brownfield plugin.

### Test plan

<img width="196" alt="image" src="https://github.com/user-attachments/assets/6982ec50-d78b-4dd9-8dee-2283780be20d" />


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
