### PR TITLE
fix: cli broken links to docs

### DIFF
--- a/.changeset/moody-adults-help.md
+++ b/.changeset/moody-adults-help.md
@@ -1,0 +1,5 @@
+---
+'@rnef/provider-github': patch
+---
+
+Fix broken GH token docs links

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -92,7 +92,7 @@ Update the token under "${color.bold(
         )}" key in ${colorLink('rnef.config.mjs')} config file.
 
 📘 Read more about generating a new token: ${colorLink(
-          'https://rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
+          'https://rnef.dev/docs/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
         )}`
       );
     }
@@ -108,7 +108,7 @@ Make sure the repository information and token under "${color.bold(
         )}" key in ${colorLink('rnef.config.mjs')} config file is valid.
 
 📘 Read more about generating a new token: ${colorLink(
-          'https://rnef.dev/docs/remote-cache/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
+          'https://rnef.dev/docs/github-actions/configuration#generate-github-personal-access-token-for-downloading-cached-builds'
         )}`
       );
     }


### PR DESCRIPTION
### Summary

This PR provides a fix for the CLI, which - when run without the user logged in - prints the below message containing outdated links leading to a 404 page:

<img width="1263" height="168" alt="image" src="https://github.com/user-attachments/assets/2debd7fc-b375-4a8c-abf4-da1c93c84c64" />

### Test plan

- verify the link is valid