### PR TITLE
fix: add ios/tmp.xcconfig from react-native-config to fingerprint ignores

### DIFF
--- a/.changeset/swift-months-cover.md
+++ b/.changeset/swift-months-cover.md
@@ -1,0 +1,5 @@
+---
+'@rnef/tools': patch
+---
+
+fix: add ios/tmp.xcconfig from react-native-config to fingerprint ignores

--- a/packages/tools/src/lib/fingerprint/index.ts
+++ b/packages/tools/src/lib/fingerprint/index.ts
@@ -58,6 +58,7 @@ export async function nativeFingerprint(
       'android/**/.cxx',
       'ios/DerivedData',
       'ios/Pods',
+      'ios/tmp.xcconfig', // added by react-native-config
       'node_modules',
       'android/local.properties',
       'android/.idea',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Projects using `react-native-config` library will add `ios/tmp.xcconfig` file that they instruct to git-ignore. Since it's a popular library, I'm adding it to default excludes.

Next step would be to read gitignore and apply patterns from there

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
