### PR TITLE
fix: assets not available in welcome-screen

### DIFF
--- a/.changeset/modern-ears-fetch.md
+++ b/.changeset/modern-ears-fetch.md
@@ -1,0 +1,5 @@
+---
+'@rnef/welcome-screen': patch
+---
+
+fix: assets not available in welcome-screen

--- a/packages/welcome-screen/package.json
+++ b/packages/welcome-screen/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.lib.json",
+    "build": "tsc -p tsconfig.lib.json && cp -r src/assets dist/src/assets",
     "dev": "tsc -p tsconfig.lib.json --watch",
     "publish:npm": "npm publish --access public",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Assets are non-TS so `tsc` doesn't copy them. Let's do that manually in the build script

### Test plan

Run build, and see assets being copied
<img width="230" height="227" alt="image" src="https://github.com/user-attachments/assets/794b4329-84c7-4424-9d41-76bad558f15c" />

