### PR TITLE
fix: infinite loop while fetching more than one page in remote-cache list-all command

### DIFF
--- a/.changeset/tricky-mangos-confess.md
+++ b/.changeset/tricky-mangos-confess.md
@@ -1,0 +1,5 @@
+---
+'@rnef/provider-github': patch
+---
+
+Fix infinite loop in remote-cache list-all command when GH returns more than one page of results

--- a/packages/provider-github/src/lib/artifacts.ts
+++ b/packages/provider-github/src/lib/artifacts.ts
@@ -41,12 +41,12 @@ export async function fetchGitHubArtifactsByName(
   const result: GitHubArtifact[] = [];
   const owner = repoDetails.owner;
   const repo = repoDetails.repository;
-  const url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?per_page=${
-    limit ?? PAGE_SIZE
-  }&page=${page}${name ? `&name=${name}` : ''}`;
 
   try {
     while (true) {
+      const url = `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?per_page=${
+        limit ?? PAGE_SIZE
+      }&page=${page}${name ? `&name=${name}` : ''}`;
       let data: GitHubArtifactResponse;
       try {
         const response = await fetch(url, {


### PR DESCRIPTION
### Summary

When I developed e2e tests for RN Legal, I was suggested to use a new script `remote-cache download` instead of downloading the artefact by myself.
I wanted to list all the artefacts locally, but the script went into an infinite loop. After a short investigation, it turned out that the script fetches 100 elements from GitHub and goes to the second iteration of the loop. The problem is that the URL is set outside the loop body, and there is no chance to change the page, so the script always fetches the first page and gets stuck in an infinite loop.

### Test plan

**prerequisites**
1. User must have more than 100 elements in cache, or change `PAGE_SIZE` constant from `artifacts.ts` from `provider-github` package. 
2. The GH cache must be set up in a project.

**test steps**
1. Run `npx rnef remote-cache list-all`

**expected outcome**
The test should finish, and some artefacts will be displayed on the screen.





