### PR TITLE
chore: migrate actions to v2

### DIFF
--- a/packages/platform-android/template/.github/workflows/remote-build-android.yml
+++ b/packages/platform-android/template/.github/workflows/remote-build-android.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: RNEF Remote Build - Android device
-        uses: callstackincubator/android@v1
+        uses: callstackincubator/android@v2
         with:
           sign: true
           variant: release
@@ -58,7 +58,7 @@ jobs:
         run: npm install
 
       - name: RNEF Remote Build - Android
-        uses: callstackincubator/android@v1
+        uses: callstackincubator/android@v2
         with:
           variant: debug
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
+++ b/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: RNEF Remote Build - iOS device
-        uses: callstackincubator/ios@v1
+        uses: callstackincubator/ios@v2
         with:
           destination: device
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
         run: npm install
 
       - name: RNEF Remote Build - iOS simulator
-        uses: callstackincubator/ios@v1
+        uses: callstackincubator/ios@v2
         with:
           destination: simulator
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/website/src/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/src/docs/getting-started/migrating-from-community-cli.mdx
@@ -146,7 +146,7 @@ import { PackageManagerTabs } from 'rspress/theme';
    ```yaml title=".github/workflows/build-ios"
    - name: RNEF Remote Build - iOS simulator
      id: rnef-remote-build-ios
-     uses: callstackincubator/ios@v1
+     uses: callstackincubator/ios@v2
      with:
        destination: simulator
        github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ import { PackageManagerTabs } from 'rspress/theme';
    ```yaml title=".github/workflows/build-android"
    - name: RNEF Remote Build - Android
      id: rnef-remote-build-android
-     uses: callstackincubator/android@v1
+     uses: callstackincubator/android@v2
      with:
        variant: debug
        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/website/src/docs/github-actions/android.md
+++ b/website/src/docs/github-actions/android.md
@@ -13,7 +13,7 @@ Use in the GitHub Workflow file like this:
 ```yaml
 - name: RNEF Remote Build - Android
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: debug
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ Use in the GitHub Workflow file like this:
 ```yaml
 - name: RNEF Remote Build - Android device
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: release
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ Pass extra parameters to the `rnef build:android` command, in order to apply cus
 ```yaml
 - name: RNEF Remote Build - Android
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: release
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +88,7 @@ To avoid polluting artifact storage it will also handle removal of old artifacts
 ```yaml
 - name: RNEF Remote Build - Android
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: release
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +104,7 @@ For security reasons we add Gradle Wrapper validation step to Android build acti
 ```yaml
 - name: RNEF Remote Build - Android
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: debug
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -132,7 +132,7 @@ You'll need to set `working-directory: ./packages/mobile`:
 ```yaml
 - name: RNEF Remote Build - Android
   id: rnef-remote-build-android
-  uses: callstackincubator/android@v1
+  uses: callstackincubator/android@v2
   with:
     variant: debug
     github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/website/src/docs/github-actions/ios.md
+++ b/website/src/docs/github-actions/ios.md
@@ -11,7 +11,7 @@ Use in the GitHub Workflow file like this:
 ```yaml
 - name: RNEF Remote Build - iOS simulator
   id: rnef-remote-build-ios
-  uses: callstackincubator/ios@v1
+  uses: callstackincubator/ios@v2
   with:
     destination: simulator
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ Use in the GitHub Workflow file like this:
 ```yaml
 - name: RNEF Remote Build - iOS device
   id: rnef-remote-build-ios
-  uses: callstackincubator/ios@v1
+  uses: callstackincubator/ios@v2
   with:
     destination: device
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -146,7 +146,7 @@ Pass extra parameters to the `rnef build:ios` command, in order to apply custom 
 ```yaml
 - name: RNEF Remote Build - iOS device
   id: rnef-remote-build-ios
-  uses: callstackincubator/ios@v1
+  uses: callstackincubator/ios@v2
   with:
     destination: device
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -164,7 +164,7 @@ To avoid polluting artifact storage it will also handle removal of old artifacts
 ```yaml
 - name: RNEF Remote Build - iOS device
   id: rnef-remote-build-ios
-  uses: callstackincubator/ios@v1
+  uses: callstackincubator/ios@v2
   with:
     destination: device
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -193,7 +193,7 @@ You'll need to set `working-directory: ./packages/mobile`:
 ```yaml
 - name: RNEF Remote Build - iOS device
   id: rnef-remote-build-ios
-  uses: callstackincubator/ios@v1
+  uses: callstackincubator/ios@v2
   with:
     destination: device
     github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Migrate to use `callstackincubator/ios@v2` and `callstackincubator/android@v2` actions in our templates and the docs. The actions are marked as a breaking change, but only as a cautionary step, as we replaced underlying mechanism. The API stays the same, so practically it's not breaking—and if it is, we need to fix it anyway.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
