### PR TITLE
fix: upload app.tar.gz with binary-path

### DIFF
--- a/packages/cli/src/lib/plugins/remoteCache.ts
+++ b/packages/cli/src/lib/plugins/remoteCache.ts
@@ -20,7 +20,7 @@ type Flags = {
   json?: boolean;
   all?: boolean;
   allButLatest?: boolean;
-  binaryPath?: string
+  binaryPath?: string;
 };
 
 async function remoteCache({
@@ -121,15 +121,22 @@ async function remoteCache({
     }
     case 'upload': {
       const localArtifactPath = getLocalArtifactPath(artifactName);
-      const binaryPath = args.binaryPath ?? getLocalBinaryPath(localArtifactPath);
+      const binaryPath =
+        args.binaryPath ?? getLocalBinaryPath(localArtifactPath);
       if (!binaryPath) {
         throw new RnefError(`No binary found for "${artifactName}".`);
       }
       const zip = new AdmZip();
-      const absoluteTarballPath = path.join(localArtifactPath, 'app.tar.gz');
+      const absoluteTarballPath =
+        args.binaryPath ?? path.join(localArtifactPath, 'app.tar.gz');
       const isAppDirectory = fs.statSync(binaryPath).isDirectory();
       if (isAppDirectory) {
         const appName = path.basename(binaryPath);
+        if (!fs.existsSync(absoluteTarballPath)) {
+          throw new RnefError(
+            `No tarball found for "${artifactName}" in "${localArtifactPath}".`
+          );
+        }
         await tar.create(
           {
             file: absoluteTarballPath,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a case where `remote-cache upload --binary-path <path>` would still try to look for artifact passed with `--name` param, even though it may not exist locally (e.g. when re-signing in a PR)  

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
