### PR TITLE
fix: get scheme from args if available

### DIFF
--- a/.changeset/eleven-buckets-joke.md
+++ b/.changeset/eleven-buckets-joke.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: get scheme from args if available

--- a/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/createBuild.ts
@@ -45,7 +45,7 @@ export const createBuild = async ({
 
   let xcodeProject: XcodeProjectInfo;
   let sourceDir: string;
-  let scheme: string | undefined;
+  let scheme = args.scheme;
   const deviceOrSimulator = args.destination
     ? // there can be multiple destinations, so we'll pick the first one
       args.destination[0].match(/simulator/i)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Scheme is passed as argument in brownfield setup, and without this the outputPath for the framework will be undefined.

cc @andrei-zgirvaci 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
