### PR TITLE
fix: stdout buffer overflow and excessive logs accumulation when building for iOS

### DIFF
--- a/.changeset/strong-zebras-juggle.md
+++ b/.changeset/strong-zebras-juggle.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: stdout buffer overflow and excessive logs accumulation when building ios

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,5 @@
 dist/
 coverage/
 pnpm-lock.yaml
-build/
+website/build/
 ios/

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -134,10 +134,12 @@ Configuration   ${color.bold(configuration)}`);
       cwd: sourceDir,
     });
 
-    // Process the output from the AsyncIterable
-    for await (const chunk of process) {
-      commandOutput += chunk + '\n';
-      reportProgress(chunk, loader, message);
+    if (!logger.isVerbose()) {
+      // Process the output from the AsyncIterable
+      for await (const chunk of process) {
+        commandOutput += chunk + '\n';
+        reportProgress(chunk, loader, message);
+      }
     }
 
     await process;
@@ -150,7 +152,7 @@ Configuration   ${color.bold(configuration)}`);
       );
     }
     if (commandOutput) {
-      logger.error(`xcodebuild output: ${commandOutput}`);
+      console.error(color.red(`xcodebuild output: ${commandOutput}`));
       throw new RnefError(
         'Running xcodebuild failed. See error details above.',
       );

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildProject.ts
@@ -152,6 +152,7 @@ Configuration   ${color.bold(configuration)}`);
       );
     }
     if (commandOutput) {
+      // Use lightweight console.error instead of logger.error to avoid stack overflow issues when Xcode logs go crazy
       console.error(color.red(`xcodebuild output: ${commandOutput}`));
       throw new RnefError(
         'Running xcodebuild failed. See error details above.',


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Use lightweight `console.error` instead of `logger.error` to avoid stack overflow issues when Xcode logs go crazy.

Fixes #495 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
